### PR TITLE
feat(*): allow changing mesos URL

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -1,7 +1,7 @@
 import { request as httpRequest } from "@dcos/http-service";
 
-export default function request(body, baseUrl = "") {
-  return httpRequest(`${baseUrl}/mesos/api/v1`, {
+export default function request(body, url = "/mesos/api/v1") {
+  return httpRequest(url, {
     method: "POST",
     body: JSON.stringify(body),
     responseType: "json",

--- a/src/stream/index.js
+++ b/src/stream/index.js
@@ -4,8 +4,8 @@ import parseRecordioRecords from "./parseRecordioRecords";
 
 const TIMEOUT = 30000;
 
-export default function stream(body, baseUrl = "") {
-  const resource = httpStream(`${baseUrl}/mesos/api/v1`, {
+export default function stream(body, url = "/mesos/api/v1") {
+  const resource = httpStream(url, {
     method: "POST",
     body: JSON.stringify(body),
     responseType: "text",


### PR DESCRIPTION
BREAKING: the second argument in both request and stream functions changes its behaviour
Instead of being a baseUrl it is becomming a complete url:

```javascript
request({...}, "base/url") -> request({...}, "base/url/mesos/api/v1")
stream({...}, "base/url") -> stream({...}, "base/url/mesos/api/v1")
```