### PR TITLE
feat(request): switch from json to raw text response

### DIFF
--- a/src/request.js
+++ b/src/request.js
@@ -4,7 +4,7 @@ export default function request(body, url = "/mesos/api/v1") {
   return httpRequest(url, {
     method: "POST",
     body: JSON.stringify(body),
-    responseType: "json",
+    responseType: "text",
     headers: {
       "Content-Type": "application/json",
       Accept: "application/json"


### PR DESCRIPTION
BREAKING CHANGE: Switching from parsed JSON to raw text response
as a return value for `request` function.

As `stream` function returns raw text and not JSON we've made a decision
to unify the interface

Before:
```javascript
request({...}).subscribe((jsonData) => ...);
```

After:
```javascript
request({...}).map(data => JSON.parse(data)).subscribe((jsonData) => ...);
```