### PR TITLE
fix(stream): remove timeout

### DIFF
--- a/src/stream/index.js
+++ b/src/stream/index.js
@@ -2,8 +2,6 @@ import { stream as httpStream } from "@dcos/http-service";
 
 import parseRecordioRecords from "./parseRecordioRecords";
 
-const TIMEOUT = 30000;
-
 export default function stream(body, url = "/mesos/api/v1") {
   const resource = httpStream(url, {
     method: "POST",
@@ -14,7 +12,6 @@ export default function stream(body, url = "/mesos/api/v1") {
       Accept: "application/json"
     }
   })
-    .timeout(TIMEOUT)
     .retry(-1);
 
   return parseRecordioRecords(resource);


### PR DESCRIPTION
Remove the arbitrary timeout to avoid unnecessary retries in case a user has a super slow connection.