### PR TITLE
feat(stream/index): remove retry(-1)

### DIFF
--- a/src/stream/index.js
+++ b/src/stream/index.js
@@ -11,8 +11,7 @@ export default function stream(body, url = "/mesos/api/v1") {
       "Content-Type": "application/json",
       Accept: "application/json"
     }
-  })
-    .retry(-1);
+  });
 
   return parseRecordioRecords(resource);
 }


### PR DESCRIPTION
BREAKING CHANGE: stream won't retry automatically when connection drops
From now on you should implement the retry mechanism in your application.

Before:

```
stream({ type: "SUBSCRIBE" }).subscribe(...);
```

After:

```
stream({ type: "SUBSCRIBE" }).retry(-1).subscribe(...);
```