### PR TITLE
chore(deps): update dependency babel-jest to v23 - autoclosed

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
-    "babel-jest": "^21.2.0",
+    "babel-jest": "^23.0.0",
     "babel-preset-env": "^1.6.1",
     "jest": "^21.2.1",
     "jest-cli": "^22.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -432,6 +432,13 @@ babel-jest@^22.4.3:
     babel-plugin-istanbul "^4.1.5"
     babel-preset-jest "^22.4.3"
 
+babel-jest@^23.0.0:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-23.4.2.tgz#f276de67798a5d68f2d6e87ff518c2f6e1609877"
+  dependencies:
+    babel-plugin-istanbul "^4.1.6"
+    babel-preset-jest "^23.2.0"
+
 babel-messages@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
@@ -452,7 +459,7 @@ babel-plugin-istanbul@^4.0.0:
     istanbul-lib-instrument "^1.7.5"
     test-exclude "^4.1.1"
 
-babel-plugin-istanbul@^4.1.5:
+babel-plugin-istanbul@^4.1.5, babel-plugin-istanbul@^4.1.6:
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"
   dependencies:
@@ -468,6 +475,10 @@ babel-plugin-jest-hoist@^21.2.0:
 babel-plugin-jest-hoist@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.3.tgz#7d8bcccadc2667f96a0dcc6afe1891875ee6c14a"
+
+babel-plugin-jest-hoist@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz#e61fae05a1ca8801aadee57a6d66b8cefaf44167"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -737,6 +748,13 @@ babel-preset-jest@^22.4.3:
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-22.4.3.tgz#e92eef9813b7026ab4ca675799f37419b5a44156"
   dependencies:
     babel-plugin-jest-hoist "^22.4.3"
+    babel-plugin-syntax-object-rest-spread "^6.13.0"
+
+babel-preset-jest@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz#8ec7a03a138f001a1a8fb1e8113652bf1a55da46"
+  dependencies:
+    babel-plugin-jest-hoist "^23.2.0"
     babel-plugin-syntax-object-rest-spread "^6.13.0"
 
 babel-register@^6.26.0:


### PR DESCRIPTION
<p>This Pull Request updates dependency <a href="https://renovatebot.com/gh/facebook/jest">babel-jest</a> from <code>^21.2.0</code> to <code>^23.0.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v2342httpsgithubcomfacebookjestblobmasterchangelogmd82032342"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2342"><code>v23.4.2</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v23.4.0…v23.4.2">Compare Source</a></p>
<h5 id="performance">Performance</h5>
<ul>
<li><code>[jest-changed-files]</code> limit git and hg commands to specified roots (<a href="https://renovatebot.com/gh/facebook/jest/pull/6732">#&#8203;6732</a>)</li>
</ul>
<h5 id="fixes">Fixes</h5>
<ul>
<li><code>[jest-circus]</code> Fix retryTimes so errors are reset before re-running (<a href="https://renovatebot.com/gh/facebook/jest/pull/6762">#&#8203;6762</a>)</li>
<li><code>[docs]</code> Update <code>expect.objectContaining()</code> description (<a href="https://renovatebot.com/gh/facebook/jest/pull/6754">#&#8203;6754</a>)</li>
<li><code>[babel-jest]</code> Make <code>getCacheKey()</code> take into account <code>createTransformer</code> options (<a href="https://renovatebot.com/gh/facebook/jest/pull/6699">#&#8203;6699</a>)</li>
<li><code>[jest-jasmine2]</code> Use prettier through <code>require</code> instead of <code>localRequire</code>. Fixes <code>matchInlineSnapshot</code> where prettier dependencies like <code>path</code> and <code>fs</code> are mocked with <code>jest.mock</code>. (<a href="https://renovatebot.com/gh/facebook/jest/pull/6776">#&#8203;6776</a>)</li>
<li><code>[docs]</code> Fix contributors link (<a href="https://renovatebot.com/gh/facebook/jest/pull/6711">#&#8203;6711</a>)</li>
<li><code>[website]</code> Fix website versions page to link to correct language (<a href="https://renovatebot.com/gh/facebook/jest/pull/6734">#&#8203;6734</a>)</li>
</ul>
<hr />
<h3 id="v2340httpsgithubcomfacebookjestblobmasterchangelogmd82032340"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2340"><code>v23.4.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v23.2.0…v23.4.0">Compare Source</a></p>
<h5 id="features">Features</h5>
<ul>
<li><code>[jest-haste-map]</code> Add <code>computeDependencies</code> flag to avoid opening files if not needed (<a href="https://renovatebot.com/gh/facebook/jest/pull/6667">#&#8203;6667</a>)</li>
<li><code>[jest-runtime]</code> Support <code>require.resolve.paths</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6471">#&#8203;6471</a>)</li>
<li><code>[jest-runtime]</code> Support <code>paths</code> option for <code>require.resolve</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6471">#&#8203;6471</a>)</li>
</ul>
<h5 id="fixes-1">Fixes</h5>
<ul>
<li><code>[jest-runner]</code> Force parallel runs for watch mode, to avoid TTY freeze (<a href="https://renovatebot.com/gh/facebook/jest/pull/6647">#&#8203;6647</a>)</li>
<li><code>[jest-cli]</code> properly reprint resolver errors in watch mode (<a href="https://renovatebot.com/gh/facebook/jest/pull/6407">#&#8203;6407</a>)</li>
<li><code>[jest-cli]</code> Write configuration to stdout when the option was explicitly passed to Jest (<a href="https://renovatebot.com/gh/facebook/jest/pull/6447">#&#8203;6447</a>)</li>
<li><code>[jest-cli]</code> Fix regression on non-matching suites (<a href="https://renovatebot.com/gh/facebook/jest/pull/6657">6657</a>)</li>
<li><code>[jest-runtime]</code> Roll back <code>micromatch</code> version to prevent regression when matching files (<a href="https://renovatebot.com/gh/facebook/jest/pull/6661">#&#8203;6661</a>)</li>
</ul>
<hr />
<h3 id="v2320httpsgithubcomfacebookjestblobmasterchangelogmd82032320"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2320"><code>v23.2.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v23.0.1…v23.2.0">Compare Source</a></p>
<h5 id="features-1">Features</h5>
<ul>
<li><code>[jest-each]</code> Add support for keyPaths in test titles (<a href="https://renovatebot.com/gh/facebook/jest/pull/6457">#&#8203;6457</a>)</li>
<li><code>[jest-cli]</code> Add <code>jest --init</code> option that generates a basic configuration file with a short description for each option (<a href="https://renovatebot.com/gh/facebook/jest/pull/6442">#&#8203;6442</a>)</li>
<li><code>[jest.retryTimes]</code> Add <code>jest.retryTimes()</code> option that allows failed tests to be retried n-times when using jest-circus. (<a href="https://renovatebot.com/gh/facebook/jest/pull/6498">#&#8203;6498</a>)</li>
</ul>
<h5 id="fixes-2">Fixes</h5>
<ul>
<li><code>[jest-cli]</code> Add check to make sure one or more tests have run before notifying when using <code>--notify</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6495">#&#8203;6495</a>)</li>
<li><code>[jest-cli]</code> Pass <code>globalConfig</code> as a parameter to <code>globalSetup</code> and <code>globalTeardown</code> functions (<a href="https://renovatebot.com/gh/facebook/jest/pull/6486">#&#8203;6486</a>)</li>
<li><code>[jest-config]</code> Add missing options to the <code>defaults</code> object (<a href="https://renovatebot.com/gh/facebook/jest/pull/6428">#&#8203;6428</a>)</li>
<li><code>[expect]</code> Using symbolic property names in arrays no longer causes the <code>toEqual</code> matcher to fail (<a href="https://renovatebot.com/gh/facebook/jest/pull/6391">#&#8203;6391</a>)</li>
<li><code>[expect]</code> <code>toEqual</code> no longer tries to compare non-enumerable symbolic properties, to be consistent with non-symbolic properties. (<a href="https://renovatebot.com/gh/facebook/jest/pull/6398">#&#8203;6398</a>)</li>
<li><code>[jest-util]</code> <code>console.timeEnd</code> now properly log elapsed time in milliseconds. (<a href="https://renovatebot.com/gh/facebook/jest/pull/6456">#&#8203;6456</a>)</li>
<li><code>[jest-mock]</code> Fix <code>MockNativeMethods</code> access in react-native <code>jest.mock()</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6505">#&#8203;6505</a>)</li>
</ul>
<h5 id="chore--maintenance">Chore &amp; Maintenance</h5>
<ul>
<li><code>[docs]</code> Add jest-each docs for 1 dimensional arrays (<a href="https://renovatebot.com/gh/facebook/jest/pull/6444/files">#&#8203;6444</a>)</li>
</ul>
<hr />
<h3 id="v2301httpsgithubcomfacebookjestblobmasterchangelogmd82032301"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2301"><code>v23.0.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v23.0.0…v23.0.1">Compare Source</a></p>
<h5 id="chore--maintenance-1">Chore &amp; Maintenance</h5>
<ul>
<li><code>[jest-jasemine2]</code> Add dependency on jest-each (<a href="https://renovatebot.com/gh/facebook/jest/pull/6308">#&#8203;6308</a>)</li>
<li><code>[jest-each]</code> Move jest-each into core Jest (<a href="https://renovatebot.com/gh/facebook/jest/pull/6278">#&#8203;6278</a>)</li>
<li><code>[examples]</code> Update typescript example to using ts-jest (<a href="https://renovatebot.com/gh/facebook/jest/pull/6260">#&#8203;6260</a>)</li>
</ul>
<h5 id="fixes-3">Fixes</h5>
<ul>
<li><code>[pretty-format]</code> Serialize inverse asymmetric matchers correctly (<a href="https://renovatebot.com/gh/facebook/jest/pull/6272">#&#8203;6272</a>)</li>
</ul>
<hr />
<h3 id="v2300httpsgithubcomfacebookjestblobmasterchangelogmd82032300"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2300"><code>v23.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.4.4…v23.0.0">Compare Source</a></p>
<h5 id="features-2">Features</h5>
<ul>
<li><code>[expect]</code> Expose <code>getObjectSubset</code>, <code>iterableEquality</code>, and <code>subsetEquality</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6210">#&#8203;6210</a>)</li>
<li><code>[jest-snapshot]</code> Add snapshot property matchers (<a href="https://renovatebot.com/gh/facebook/jest/pull/6210">#&#8203;6210</a>)</li>
<li><code>[jest-config]</code> Support jest-preset.js files within Node modules (<a href="https://renovatebot.com/gh/facebook/jest/pull/6185">#&#8203;6185</a>)</li>
<li><code>[jest-cli]</code> Add <code>--detectOpenHandles</code> flag which enables Jest to potentially track down handles keeping it open after tests are complete. (<a href="https://renovatebot.com/gh/facebook/jest/pull/6130">#&#8203;6130</a>)</li>
<li><code>[jest-jasmine2]</code> Add data driven testing based on <code>jest-each</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6102">#&#8203;6102</a>)</li>
<li><code>[jest-matcher-utils]</code> Change "suggest to equal" message to be more advisory (<a href="https://renovatebot.com/gh/facebook/jest/issues/6103">#&#8203;6103</a>)</li>
<li><code>[jest-message-util]</code> Don't ignore messages with <code>vendor</code> anymore (<a href="https://renovatebot.com/gh/facebook/jest/pull/6117">#&#8203;6117</a>)</li>
<li><code>[jest-validate]</code> Get rid of <code>jest-config</code> dependency (<a href="https://renovatebot.com/gh/facebook/jest/pull/6067">#&#8203;6067</a>)</li>
<li><code>[jest-validate]</code> Adds option to inject <code>deprecationEntries</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6067">#&#8203;6067</a>)</li>
<li><code>[jest-snapshot]</code> [<strong>BREAKING</strong>] Concatenate name of test, optional snapshot name and count (<a href="https://renovatebot.com/gh/facebook/jest/pull/6015">#&#8203;6015</a>)</li>
<li><code>[jest-runtime]</code> Allow for transform plugins to skip the definition process method if createTransformer method was defined. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5999">#&#8203;5999</a>)</li>
<li><code>[expect]</code> Add stack trace for async errors (<a href="https://renovatebot.com/gh/facebook/jest/pull/6008">#&#8203;6008</a>)</li>
<li><code>[jest-jasmine2]</code> Add stack trace for timeouts (<a href="https://renovatebot.com/gh/facebook/jest/pull/6008">#&#8203;6008</a>)</li>
<li><code>[jest-jasmine2]</code> Add stack trace for thrown non-<code>Error</code>s (<a href="https://renovatebot.com/gh/facebook/jest/pull/6008">#&#8203;6008</a>)</li>
<li><code>[jest-runtime]</code> Prevent modules from marking themselves as their own parent (<a href="https://renovatebot.com/gh/facebook/jest/issues/5235">#&#8203;5235</a>)</li>
<li><code>[jest-mock]</code> Add support for auto-mocking generator functions (<a href="https://renovatebot.com/gh/facebook/jest/pull/5983">#&#8203;5983</a>)</li>
<li><code>[expect]</code> Add support for async matchers  (<a href="https://renovatebot.com/gh/facebook/jest/pull/5919">#&#8203;5919</a>)</li>
<li><code>[expect]</code> Suggest toContainEqual (<a href="https://renovatebot.com/gh/facebook/jest/pull/5953">#&#8203;5948</a>)</li>
<li><code>[jest-config]</code> Export Jest's default options (<a href="https://renovatebot.com/gh/facebook/jest/pull/5948">#&#8203;5948</a>)</li>
<li><code>[jest-editor-support]</code> Move <code>coverage</code> to <code>ProjectWorkspace.collectCoverage</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5929">#&#8203;5929</a>)</li>
<li><code>[jest-editor-support]</code> Add <code>coverage</code> option to runner (<a href="https://renovatebot.com/gh/facebook/jest/pull/5836">#&#8203;5836</a>)</li>
<li><code>[jest-haste-map]</code> Support extracting dynamic <code>import</code>s (<a href="https://renovatebot.com/gh/facebook/jest/pull/5883">#&#8203;5883</a>)</li>
<li><code>[expect]</code> Improve output format for mismatchedArgs in mock/spy calls. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5846">#&#8203;5846</a>)</li>
<li><code>[jest-cli]</code> Add support for using <code>--coverage</code> in combination with watch mode, <code>--onlyChanged</code>, <code>--findRelatedTests</code> and more (<a href="https://renovatebot.com/gh/facebook/jest/pull/5601">#&#8203;5601</a>)</li>
<li><code>[jest-jasmine2]</code> [<strong>BREAKING</strong>] Adds error throwing and descriptive errors to <code>it</code>/ <code>test</code> for invalid arguments. <code>[jest-circus]</code> Adds error throwing and descriptive errors to <code>it</code>/ <code>test</code> for invalid arguments (<a href="https://renovatebot.com/gh/facebook/jest/pull/5558">#&#8203;5558</a>)</li>
<li><code>[jest-matcher-utils]</code> Add <code>isNot</code> option to <code>matcherHint</code> function (<a href="https://renovatebot.com/gh/facebook/jest/pull/5512">#&#8203;5512</a>)</li>
<li><code>[jest-config]</code> Add <code>&lt;rootDir&gt;</code> to runtime files not found error report (<a href="https://renovatebot.com/gh/facebook/jest/pull/5693">#&#8203;5693</a>)</li>
<li><code>[expect]</code> Make toThrow matcher pass only if Error object is returned from promises (<a href="https://renovatebot.com/gh/facebook/jest/pull/5670">#&#8203;5670</a>)</li>
<li><code>[expect]</code> Add isError to utils (<a href="https://renovatebot.com/gh/facebook/jest/pull/5670">#&#8203;5670</a>)</li>
<li><code>[expect]</code> Add inverse matchers (<code>expect.not.arrayContaining</code>, etc., <a href="https://renovatebot.com/gh/facebook/jest/pull/5517">#&#8203;5517</a>)</li>
<li><code>[expect]</code> <code>expect.extend</code> now also extends asymmetric matchers (<a href="https://renovatebot.com/gh/facebook/jest/pull/5503">#&#8203;5503</a>)</li>
<li><code>[jest-mock]</code> Update <code>spyOnProperty</code> to support spying on the prototype chain (<a href="https://renovatebot.com/gh/facebook/jest/pull/5753">#&#8203;5753</a>)</li>
<li><code>[jest-mock]</code> Add tracking of return values in the <code>mock</code> property (<a href="https://renovatebot.com/gh/facebook/jest/pull/5752">#&#8203;5752</a>)</li>
<li><code>[jest-mock]</code> Add tracking of thrown errors in the <code>mock</code> property (<a href="https://renovatebot.com/gh/facebook/jest/pull/5764">#&#8203;5764</a>)</li>
<li><code>[expect]</code>Add nthCalledWith spy matcher (<a href="https://renovatebot.com/gh/facebook/jest/pull/5605">#&#8203;5605</a>)</li>
<li><code>[jest-cli]</code> Add <code>isSerial</code> property that runners can expose to specify that they can not run in parallel (<a href="https://renovatebot.com/gh/facebook/jest/pull/5706">#&#8203;5706</a>)</li>
<li><code>[expect]</code> Add <code>.toBeCalledTimes</code> and <code>toHaveBeenNthCalledWith</code> aliases (<a href="https://renovatebot.com/gh/facebook/jest/pull/5826">#&#8203;5826</a>)</li>
<li><code>[jest-cli]</code> Interactive Snapshot Mode improvements (<a href="https://renovatebot.com/gh/facebook/jest/pull/5864">#&#8203;5864</a>)</li>
<li><code>[jest-editor-support]</code> Add <code>no-color</code> option to runner (<a href="https://renovatebot.com/gh/facebook/jest/pull/5909">#&#8203;5909</a>)</li>
<li><code>[jest-jasmine2]</code> Pretty-print non-Error object errors (<a href="https://renovatebot.com/gh/facebook/jest/pull/5980">#&#8203;5980</a>)</li>
<li><code>[jest-message-util]</code> Include column in stack frames (<a href="https://renovatebot.com/gh/facebook/jest/pull/5889">#&#8203;5889</a>)</li>
<li><code>[expect]</code> Introduce toStrictEqual (<a href="https://renovatebot.com/gh/facebook/jest/pull/6032">#&#8203;6032</a>)</li>
<li><code>[expect]</code> Add return matchers (<a href="https://renovatebot.com/gh/facebook/jest/pull/5879">#&#8203;5879</a>)</li>
<li><code>[jest-cli]</code> Improve snapshot summaries (<a href="https://renovatebot.com/gh/facebook/jest/pull/6181">#&#8203;6181</a>)</li>
<li><code>[expect]</code> Include custom mock names in error messages (<a href="https://renovatebot.com/gh/facebook/jest/pull/6199">#&#8203;6199</a>)</li>
<li><code>[jest-diff]</code> Support returning diff from oneline strings (<a href="https://renovatebot.com/gh/facebook/jest/pull/6221">#&#8203;6221</a>)</li>
<li><code>[expect]</code> Improve return matchers (<a href="https://renovatebot.com/gh/facebook/jest/pull/6172">#&#8203;6172</a>)</li>
<li><code>[jest-cli]</code> Overhaul watch plugin hooks names (<a href="https://renovatebot.com/gh/facebook/jest/pull/6249">#&#8203;6249</a>)</li>
<li><code>[jest-mock]</code> Include tracked call results in serialized mock (<a href="https://renovatebot.com/gh/facebook/jest/pull/6244">#&#8203;6244</a>)</li>
</ul>
<h5 id="fixes-4">Fixes</h5>
<ul>
<li><code>[jest-cli]</code> Fix stdin encoding to utf8 for watch plugins. (<a href="https://renovatebot.com/gh/facebook/jest/issues/6253">#&#8203;6253</a>)</li>
<li><code>[expect]</code> Better detection of DOM Nodes for equality (<a href="https://renovatebot.com/gh/facebook/jest/pull/6246">#&#8203;6246</a>)</li>
<li><code>[jest-cli]</code> Fix misleading action description for F key when in "only failed tests" mode. (<a href="https://renovatebot.com/gh/facebook/jest/issues/6167">#&#8203;6167</a>)</li>
<li><code>[jest-worker]</code> Stick calls to workers before processing them (<a href="https://renovatebot.com/gh/facebook/jest/pull/6073">#&#8203;6073</a>)</li>
<li><code>[babel-plugin-jest-hoist]</code> Allow using <code>console</code> global variable (<a href="https://renovatebot.com/gh/facebook/jest/pull/6075">#&#8203;6075</a>)</li>
<li><code>[jest-jasmine2]</code> Always remove node core message from assert stack traces (<a href="https://renovatebot.com/gh/facebook/jest/pull/6055">#&#8203;6055</a>)</li>
<li><code>[expect]</code> Add stack trace when <code>expect.assertions</code> and <code>expect.hasAssertions</code> causes test failures. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5997">#&#8203;5997</a>)</li>
<li><code>[jest-runtime]</code> Throw a more useful error when trying to require modules after the test environment is torn down (<a href="https://renovatebot.com/gh/facebook/jest/pull/5888">#&#8203;5888</a>)</li>
<li><code>[jest-mock]</code> [<strong>BREAKING</strong>] Replace timestamps with <code>invocationCallOrder</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5867">#&#8203;5867</a>)</li>
<li><code>[jest-jasmine2]</code> Install <code>sourcemap-support</code> into normal runtime to catch runtime errors (<a href="https://renovatebot.com/gh/facebook/jest/pull/5945">#&#8203;5945</a>)</li>
<li><code>[jest-jasmine2]</code> Added assertion error handling inside <code>afterAll hook</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5884">#&#8203;5884</a>)</li>
<li><code>[jest-cli]</code> Remove the notifier actions in case of failure when not in watch mode. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5861">#&#8203;5861</a>)</li>
<li><code>[jest-mock]</code> Extend .toHaveBeenCalled return message with outcome (<a href="https://renovatebot.com/gh/facebook/jest/pull/5951">#&#8203;5951</a>)</li>
<li><code>[jest-runner]</code> Assign <code>process.env.JEST_WORKER_ID="1"</code> when in runInBand mode (<a href="https://renovatebot.com/gh/facebook/jest/pull/5860">#&#8203;5860</a>)</li>
<li><code>[jest-cli]</code> Add descriptive error message when trying to use <code>globalSetup</code>/<code>globalTeardown</code> file that doesn't export a function. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5835">#&#8203;5835</a>)</li>
<li><code>[expect]</code> Do not rely on <code>instanceof RegExp</code>, since it will not work for RegExps created inside of a different VM (<a href="https://renovatebot.com/gh/facebook/jest/pull/5729">#&#8203;5729</a>)</li>
<li><code>[jest-resolve]</code> Update node module resolution algorithm to correctly handle symlinked paths (<a href="https://renovatebot.com/gh/facebook/jest/pull/5085">#&#8203;5085</a>)</li>
<li><code>[jest-editor-support]</code> Update <code>Settings</code> to use spawn in shell option (<a href="https://renovatebot.com/gh/facebook/jest/pull/5658">#&#8203;5658</a>)</li>
<li><code>[jest-cli]</code> Improve the error message when 2 projects resolve to the same config (<a href="https://renovatebot.com/gh/facebook/jest/pull/5674">#&#8203;5674</a>)</li>
<li><code>[jest-runtime]</code> remove retainLines from coverage instrumentation (<a href="https://renovatebot.com/gh/facebook/jest/pull/5692">#&#8203;5692</a>)</li>
<li><code>[jest-cli]</code> Fix update snapshot issue when using watchAll (<a href="https://renovatebot.com/gh/facebook/jest/pull/5696">#&#8203;5696</a>)</li>
<li><code>[expect]</code> Fix rejects.not matcher (<a href="https://renovatebot.com/gh/facebook/jest/pull/5670">#&#8203;5670</a>)</li>
<li><code>[jest-runtime]</code> Prevent Babel warnings on large files (<a href="https://renovatebot.com/gh/facebook/jest/pull/5702">#&#8203;5702</a>)</li>
<li><code>[jest-mock]</code> Prevent <code>mockRejectedValue</code> from causing unhandled rejection (<a href="https://renovatebot.com/gh/facebook/jest/pull/5720">#&#8203;5720</a>)</li>
<li><code>[pretty-format]</code> Handle React fragments better (<a href="https://renovatebot.com/gh/facebook/jest/pull/5816">#&#8203;5816</a>)</li>
<li><code>[pretty-format]</code> Handle formatting of <code>React.forwardRef</code> and <code>Context</code> components (<a href="https://renovatebot.com/gh/facebook/jest/pull/6093">#&#8203;6093</a>)</li>
<li><code>[jest-cli]</code> Switch collectCoverageFrom back to a string (<a href="https://renovatebot.com/gh/facebook/jest/pull/5914">#&#8203;5914</a>)</li>
<li><code>[jest-regex-util]</code> Fix handling regex symbols in tests path on Windows (<a href="https://renovatebot.com/gh/facebook/jest/pull/5941">#&#8203;5941</a>)</li>
<li><code>[jest-util]</code> Fix handling of NaN/Infinity in mock timer delay (<a href="https://renovatebot.com/gh/facebook/jest/pull/5966">#&#8203;5966</a>)</li>
<li><code>[jest-resolve]</code> Generalise test for package main entries equivalent to ".". (<a href="https://renovatebot.com/gh/facebook/jest/pull/5968">#&#8203;5968</a>)</li>
<li><code>[jest-config]</code> Ensure that custom resolvers are used when resolving the configuration (<a href="https://renovatebot.com/gh/facebook/jest/pull/5976">#&#8203;5976</a>)</li>
<li><code>[website]</code> Fix website docs (<a href="https://renovatebot.com/gh/facebook/jest/pull/5853">#&#8203;5853</a>)</li>
<li><code>[expect]</code> Fix isEqual Set and Map to compare object values and keys regardless of order (<a href="https://renovatebot.com/gh/facebook/jest/pull/6150">#&#8203;6150</a>)</li>
<li><code>[pretty-format]</code> [<strong>BREAKING</strong>] Remove undefined props from React elements (<a href="https://renovatebot.com/gh/facebook/jest/pull/6162">#&#8203;6162</a>)</li>
<li><code>[jest-haste-map]</code> Properly resolve mocked node modules without package.json defined (<a href="https://renovatebot.com/gh/facebook/jest/pull/6232">#&#8203;6232</a>)</li>
</ul>
<h5 id="chore--maintenance-2">Chore &amp; Maintenance</h5>
<ul>
<li><code>[jest-runner]</code> Move sourcemap installation from <code>jest-jasmine2</code> to <code>jest-runner</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6176">#&#8203;6176</a>)</li>
<li><code>[jest-cli]</code> Use yargs's built-in <code>version</code> instead of rolling our own (<a href="https://renovatebot.com/gh/facebook/jest/pull/6215">#&#8203;6215</a>)</li>
<li><code>[docs]</code> Add explanation on how to mock methods not implemented in JSDOM</li>
<li><code>[jest-jasmine2]</code> Simplify <code>Env.execute</code> and TreeProcessor to setup and clean resources for the top suite the same way as for all of the children suites (<a href="https://renovatebot.com/gh/facebook/jest/pull/5885">#&#8203;5885</a>)</li>
<li><code>[babel-jest]</code> [<strong>BREAKING</strong>] Always return object from transformer (<a href="https://renovatebot.com/gh/facebook/jest/pull/5991">#&#8203;5991</a>)</li>
<li><code>[*]</code> Run Prettier on compiled output (<a href="https://renovatebot.com/gh/facebook/jest/pull/3497">#&#8203;5858</a>)</li>
<li><code>[jest-cli]</code> Add fileChange hook for plugins (<a href="https://renovatebot.com/gh/facebook/jest/pull/5708">#&#8203;5708</a>)</li>
<li><code>[docs]</code> Add docs on using <code>jest.mock(...)</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5648">#&#8203;5648</a>)</li>
<li><code>[docs]</code> Mention Jest Puppeteer Preset (<a href="https://renovatebot.com/gh/facebook/jest/pull/5722">#&#8203;5722</a>)</li>
<li><code>[docs]</code> Add jest-community section to website (<a href="https://renovatebot.com/gh/facebook/jest/pull/5675">#&#8203;5675</a>)</li>
<li><code>[docs]</code> Add versioned docs for v22.4 (<a href="https://renovatebot.com/gh/facebook/jest/pull/5733">#&#8203;5733</a>)</li>
<li><code>[docs]</code> Improve Snapshot Testing Guide (<a href="https://renovatebot.com/gh/facebook/jest/issues/5812">#&#8203;5812</a>)</li>
<li><code>[jest-runtime]</code> [<strong>BREAKING</strong>] Remove <code>jest.genMockFn</code> and <code>jest.genMockFunction</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6173">#&#8203;6173</a>)</li>
<li><code>[jest-message-util]</code> Avoid adding unnecessary indent to blank lines in stack traces (<a href="https://renovatebot.com/gh/facebook/jest/pull/6211">#&#8203;6211</a>)</li>
</ul>
<hr />
<h3 id="v2244httpsgithubcomfacebookjestcompare6851d8bc9d67e83fb1bb0199d28ef84565938225v2244"><a href="https://renovatebot.com/gh/facebook/jest/compare/6851d8bc9d67e83fb1bb0199d28ef84565938225…v22.4.4"><code>v22.4.4</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/6851d8bc9d67e83fb1bb0199d28ef84565938225…v22.4.4">Compare Source</a></p>
<hr />
<h3 id="v2241httpsgithubcomfacebookjestblobmasterchangelogmd82032241"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2241"><code>v22.4.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.4.0…v22.4.1">Compare Source</a></p>
<h5 id="fixes-5">Fixes</h5>
<ul>
<li><code>[jest-haste-map]</code> Parallelize Watchman calls in crawler (<a href="https://renovatebot.com/gh/facebook/jest/pull/5640">#&#8203;5640</a>)</li>
<li><code>[jest-editor-support]</code> Update TypeScript definitions (<a href="https://renovatebot.com/gh/facebook/jest/pull/5625">#&#8203;5625</a>)</li>
<li><code>[babel-jest]</code> Remove <code>retainLines</code> argument to babel. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5594">#&#8203;5594</a>)</li>
</ul>
<h5 id="features-3">Features</h5>
<ul>
<li><code>[jest-runtime]</code> Provide <code>require.main</code> property set to module with test suite (<a href="https://renovatebot.com/gh/facebook/jest/pull/5618">#&#8203;5618</a>)</li>
</ul>
<h5 id="chore--maintenance-3">Chore &amp; Maintenance</h5>
<ul>
<li><code>[docs]</code> Add note about Node version support (<a href="https://renovatebot.com/gh/facebook/jest/pull/5622">#&#8203;5622</a>)</li>
<li><code>[docs]</code> Update to use yarn (<a href="https://renovatebot.com/gh/facebook/jest/pull/5624">#&#8203;5624</a>)</li>
<li><code>[docs]</code> Add how to mock scoped modules to Manual Mocks doc (<a href="https://renovatebot.com/gh/facebook/jest/pull/5638">#&#8203;5638</a>)</li>
</ul>
<hr />
<h3 id="v2240httpsgithubcomfacebookjestblobmasterchangelogmd82032240"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2240"><code>v22.4.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.2.2…v22.4.0">Compare Source</a></p>
<h5 id="fixes-6">Fixes</h5>
<ul>
<li><code>[jest-haste-map]</code> Overhauls how Watchman crawler works fixing Windows (<a href="https://renovatebot.com/gh/facebook/jest/pull/5615">#&#8203;5615</a>)</li>
<li><code>[expect]</code> Allow matching of Errors against plain objects (<a href="https://renovatebot.com/gh/facebook/jest/pull/5611">#&#8203;5611</a>)</li>
<li><code>[jest-haste-map]</code> Do not read binary files in Haste, even when instructed to do so (<a href="https://renovatebot.com/gh/facebook/jest/pull/5612">#&#8203;5612</a>)</li>
<li><code>[jest-cli]</code> Don't skip matchers for exact files (<a href="https://renovatebot.com/gh/facebook/jest/pull/5582">#&#8203;5582</a>)</li>
<li><code>[docs]</code> Update discord links (<a href="https://renovatebot.com/gh/facebook/jest/pull/5586">#&#8203;5586</a>)</li>
<li><code>[jest-runtime]</code> Align handling of testRegex on Windows between searching for tests and instrumentation checks (<a href="https://renovatebot.com/gh/facebook/jest/pull/5560">#&#8203;5560</a>)</li>
<li><code>[jest-config]</code> Make it possible to merge <code>transform</code> option with preset (<a href="https://renovatebot.com/gh/facebook/jest/pull/5505">#&#8203;5505</a>)</li>
<li><code>[jest-util]</code> Fix <code>console.assert</code> behavior in custom &amp; buffered consoles (<a href="https://renovatebot.com/gh/facebook/jest/pull/5576">#&#8203;5576</a>)</li>
</ul>
<h5 id="features-4">Features</h5>
<ul>
<li><code>[docs]</code> Add MongoDB guide (<a href="https://renovatebot.com/gh/facebook/jest/pull/5571">#&#8203;5571</a>)</li>
<li><code>[jest-runtime]</code> Deprecate mapCoverage option. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5177">#&#8203;5177</a>)</li>
<li><code>[babel-jest]</code> Add option to return sourcemap from the transformer separately from source. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5177">#&#8203;5177</a>)</li>
<li><code>[jest-validate]</code> Add ability to log deprecation warnings for CLI flags. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5536">#&#8203;5536</a>)</li>
<li><code>[jest-serializer]</code> Added new module for serializing. Works using V8 or JSON (<a href="https://renovatebot.com/gh/facebook/jest/pull/5609">#&#8203;5609</a>)</li>
<li><code>[docs]</code> Add a documentation note for project <code>displayName</code> configuration (<a href="https://renovatebot.com/gh/facebook/jest/pull/5600">#&#8203;5600</a>)</li>
</ul>
<h5 id="chore--maintenance-4">Chore &amp; Maintenance</h5>
<ul>
<li><code>[docs]</code> Update automatic mocks documentation (<a href="https://renovatebot.com/gh/facebook/jest/pull/5630">#&#8203;5630</a>)</li>
</ul>
<hr />
<h3 id="v2222httpsgithubcomfacebookjestblobmasterchangelogmdjest-2222"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2222"><code>v22.2.2</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.2.0…v22.2.2">Compare Source</a></p>
<h5 id="fixes-7">Fixes</h5>
<ul>
<li><code>[babel-jest]</code> Revert "Remove retainLines from babel-jest" (<a href="https://renovatebot.com/gh/facebook/jest/pull/5496">#&#8203;5496</a>)</li>
<li><code>[jest-docblock]</code> Support multiple of the same <code>@pragma</code>. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5502">#&#8203;5154</a>)</li>
</ul>
<h5 id="features-5">Features</h5>
<ul>
<li><code>[jest-worker]</code> Assign a unique id for each worker and pass it to the child process. It will be available via <code>process.env.JEST_WORKER_ID</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5494">#&#8203;5494</a>)</li>
</ul>
<h5 id="chore--maintenance-5">Chore &amp; Maintenance</h5>
<ul>
<li><code>[filenames]</code> Standardize file names in root (<a href="https://renovatebot.com/gh/facebook/jest/pull/5500">#&#8203;5500</a>)</li>
</ul>
<hr />
<h3 id="v2220httpsgithubcomfacebookjestblobmasterchangelogmdjest-2220"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2220"><code>v22.2.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.1.0…v22.2.0">Compare Source</a></p>
<h5 id="features-6">Features</h5>
<ul>
<li><code>[jest-runner]</code> Move test summary to after coverage report (<a href="https://renovatebot.com/gh/facebook/jest/pull/4512">#&#8203;4512</a>)</li>
<li><code>[jest-cli]</code> Added <code>--notifyMode</code> to specify when to be notified. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5125">#&#8203;5125</a>)</li>
<li><code>[diff-sequences]</code> New package compares items in two sequences to find a <strong>longest common subsequence</strong>. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5407">#&#8203;5407</a>)</li>
<li><code>[jest-matcher-utils]</code> Add <code>comment</code> option to <code>matcherHint</code> function (<a href="https://renovatebot.com/gh/facebook/jest/pull/5437">#&#8203;5437</a>)</li>
<li><code>[jest-config]</code> Allow lastComit and changedFilesWithAncestor via JSON config (<a href="https://renovatebot.com/gh/facebook/jest/pull/5476">#&#8203;5476</a>)</li>
<li><code>[jest-util]</code> Add deletion to <code>process.env</code> as well (<a href="https://renovatebot.com/gh/facebook/jest/pull/5466">#&#8203;5466</a>)</li>
<li><code>[jest-util]</code> Add case-insensitive getters/setters to <code>process.env</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5465">#&#8203;5465</a>)</li>
<li><code>[jest-mock]</code> Add util methods to create async functions. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5318">#&#8203;5318</a>)</li>
</ul>
<h5 id="fixes-8">Fixes</h5>
<ul>
<li><code>[jest-cli]</code> Add trailing slash when checking root folder (<a href="https://renovatebot.com/gh/facebook/jest/pull/5464">#&#8203;5464</a>)</li>
<li><code>[jest-cli]</code> Hide interactive mode if there are no failed snapshot tests (<a href="https://renovatebot.com/gh/facebook/jest/pull/5450">#&#8203;5450</a>)</li>
<li><code>[babel-jest]</code> Remove retainLines from babel-jest (<a href="https://renovatebot.com/gh/facebook/jest/pull/5439">#&#8203;5439</a>)</li>
<li><code>[jest-cli]</code> Glob patterns ignore non-<code>require</code>-able files (e.g. <code>README.md</code>) (<a href="https://renovatebot.com/gh/facebook/jest/issues/5199">#&#8203;5199</a>)</li>
<li><code>[jest-mock]</code> Add backticks support (``) to <code>mock</code> a certain package via the <code>__mocks__</code> folder. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5426">#&#8203;5426</a>)</li>
<li><code>[jest-message-util]</code> Prevent an <code>ENOENT</code> crash when the test file contained a malformed source-map. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5405">#&#8203;5405</a>).</li>
<li><code>[jest]</code> Add <code>import-local</code> to <code>jest</code> package. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5353">#&#8203;5353</a>)</li>
<li><code>[expect]</code> Support class instances in <code>.toHaveProperty()</code> and <code>.toMatchObject</code> matcher. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5367">#&#8203;5367</a>)</li>
<li><code>[jest-cli]</code> Fix npm update command for snapshot summary. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5376">#&#8203;5376</a>, <a href="https://renovatebot.com/gh/facebook/jest/pull/5389/">5389</a>)</li>
<li><code>[expect]</code> Make <code>rejects</code> and <code>resolves</code> synchronously validate its argument. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5364">#&#8203;5364</a>)</li>
<li><code>[docs]</code> Add tutorial page for ES6 class mocks. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5383">#&#8203;5383</a>)</li>
<li><code>[jest-resolve]</code> Search required modules in node_modules and then in custom paths. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5403">#&#8203;5403</a>)</li>
<li><code>[jest-resolve]</code> Get builtin modules from node core. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5411">#&#8203;5411</a>)</li>
<li><code>[jest-resolve]</code> Detect and preserve absolute paths in <code>moduleDirectories</code>. Do not generate additional (invalid) paths by prepending each ancestor of <code>cwd</code> to the absolute path. Additionally, this fixes functionality in Windows OS. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5398">#&#8203;5398</a>)</li>
</ul>
<h5 id="chore--maintenance-6">Chore &amp; Maintenance</h5>
<ul>
<li><code>[jest-util]</code> Implement watch plugins (<a href="https://renovatebot.com/gh/facebook/jest/pull/5399">#&#8203;5399</a>)</li>
</ul>
<hr />
<h3 id="v2210httpsgithubcomfacebookjestblobmasterchangelogmdjest-2210"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2210"><code>v22.1.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/4bcfe19b89b445bec793ba0a2ac815d117fa8098…v22.1.0">Compare Source</a></p>
<h5 id="features-7">Features</h5>
<ul>
<li><code>[jest-cli]</code> Make Jest exit without an error when no tests are found in the case of <code>--lastCommit</code>, <code>--findRelatedTests</code>, or <code>--onlyChanged</code> options having been passed to the CLI</li>
<li><code>[jest-cli]</code> Add interactive snapshot mode (<a href="https://renovatebot.com/gh/facebook/jest/pull/3831">#&#8203;3831</a>)</li>
</ul>
<h5 id="fixes-9">Fixes</h5>
<ul>
<li><code>[jest-cli]</code> Use <code>import-local</code> to support global Jest installations. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5304">#&#8203;5304</a>)</li>
<li><code>[jest-runner]</code> Fix memory leak in coverage reporting (<a href="https://renovatebot.com/gh/facebook/jest/pull/5289">#&#8203;5289</a>)</li>
<li><code>[docs]</code> Update mention of the minimal version of node supported (<a href="https://renovatebot.com/gh/facebook/jest/issues/4947">#&#8203;4947</a>)</li>
<li><code>[jest-cli]</code> Fix missing newline in console message (<a href="https://renovatebot.com/gh/facebook/jest/pull/5308">#&#8203;5308</a>)</li>
<li><code>[jest-cli]</code> <code>--lastCommit</code> and <code>--changedFilesWithAncestor</code> now take effect even when <code>--onlyChanged</code> is not specified. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5307">#&#8203;5307</a>)</li>
</ul>
<h5 id="chore--maintenance-7">Chore &amp; Maintenance</h5>
<ul>
<li><code>[filenames]</code> Standardize folder names under <code>integration-tests/</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5298">#&#8203;5298</a>)</li>
</ul>
<hr />
<h3 id="v2206httpsgithubcomfacebookjestblobmasterchangelogmdjest-2206"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2206"><code>v22.0.6</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.0.4…4bcfe19b89b445bec793ba0a2ac815d117fa8098">Compare Source</a></p>
<h5 id="fixes-10">Fixes</h5>
<ul>
<li><code>[jest-jasmine2]</code> Fix memory leak in snapshot reporting (<a href="https://renovatebot.com/gh/facebook/jest/pull/5279">#&#8203;5279</a>)</li>
<li><code>[jest-config]</code> Fix breaking change in <code>--testPathPattern</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5269">#&#8203;5269</a>)</li>
<li><code>[docs]</code> Document caveat with mocks, Enzyme, snapshots and React 16 (<a href="https://renovatebot.com/gh/facebook/jest/issues/5258">#&#8203;5258</a>)</li>
</ul>
<hr />
<h3 id="v2204httpsgithubcomfacebookjestblobmasterchangelogmdjest-2204"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2204"><code>v22.0.4</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.0.3…v22.0.4">Compare Source</a></p>
<h5 id="fixes-11">Fixes</h5>
<ul>
<li><code>[jest-cli]</code> New line before quitting watch mode. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5158">#&#8203;5158</a>)</li>
</ul>
<h5 id="features-8">Features</h5>
<ul>
<li><code>[babel-jest]</code> moduleFileExtensions not passed to babel transformer. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5110">#&#8203;5110</a>)</li>
</ul>
<h5 id="chore--maintenance-8">Chore &amp; Maintenance</h5>
<ul>
<li><code>[*]</code> Tweaks to better support Node 4 (<a href="https://renovatebot.com/gh/facebook/jest/pull/5142">#&#8203;5142</a>)</li>
</ul>
<hr />
<h3 id="v2203httpsgithubcomfacebookjestblobmasterchangelogmdjest-2202--2203"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2202--2203"><code>v22.0.3</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.0.2…v22.0.3">Compare Source</a></p>
<h5 id="chore--maintenance-9">Chore &amp; Maintenance</h5>
<ul>
<li><code>[*]</code> Tweaks to better support Node 4 (<a href="https://renovatebot.com/gh/facebook/jest/pull/5134">#&#8203;5134</a>)</li>
</ul>
<hr />
<h3 id="v2202httpsgithubcomfacebookjestblobmasterchangelogmdjest-2202--2203"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2202--2203"><code>v22.0.2</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.0.1…v22.0.2">Compare Source</a></p>
<h5 id="chore--maintenance-10">Chore &amp; Maintenance</h5>
<ul>
<li><code>[*]</code> Tweaks to better support Node 4 (<a href="https://renovatebot.com/gh/facebook/jest/pull/5134">#&#8203;5134</a>)</li>
</ul>
<hr />
<h3 id="v2201httpsgithubcomfacebookjestblobmasterchangelogmdjest-2201"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2201"><code>v22.0.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.0.0…v22.0.1">Compare Source</a></p>
<h5 id="fixes-12">Fixes</h5>
<ul>
<li><code>[jest-runtime]</code> fix error for test files providing coverage. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5117">#&#8203;5117</a>)</li>
</ul>
<h5 id="features-9">Features</h5>
<ul>
<li><code>[jest-config]</code> Add <code>forceCoverageMatch</code> to allow collecting coverage from ignored files. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5081">#&#8203;5081</a>)</li>
</ul>
<hr />
<h3 id="v2200httpsgithubcomfacebookjestblobmasterchangelogmdjest-2200"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2200"><code>v22.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v21.2.0…v22.0.0">Compare Source</a></p>
<h5 id="fixes-13">Fixes</h5>
<ul>
<li><code>[jest-resolve]</code> Use <code>module.builtinModules</code> as <code>BUILTIN_MODULES</code> when it exists</li>
<li><code>[jest-worker]</code> Remove <code>debug</code> and <code>inspect</code> flags from the arguments sent to the child (<a href="https://renovatebot.com/gh/facebook/jest/pull/5068">#&#8203;5068</a>)</li>
<li><code>[jest-config]</code> Use all <code>--testPathPattern</code> and <code>&lt;regexForTestFiles&gt;</code> args in <code>testPathPattern</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5066">#&#8203;5066</a>)</li>
<li><code>[jest-cli]</code> Do not support <code>--watch</code> inside non-version-controlled environments (<a href="https://renovatebot.com/gh/facebook/jest/pull/5060">#&#8203;5060</a>)</li>
<li><code>[jest-config]</code> Escape Windows path separator in testPathPattern CLI arguments (<a href="https://renovatebot.com/gh/facebook/jest/pull/5054">#&#8203;5054</a></li>
<li><code>[jest-jasmine]</code> Register sourcemaps as node environment to improve performance with jsdom (<a href="https://renovatebot.com/gh/facebook/jest/pull/5045">#&#8203;5045</a>)</li>
<li><code>[pretty-format]</code> Do not call toJSON recursively (<a href="https://renovatebot.com/gh/facebook/jest/pull/5044">#&#8203;5044</a>)</li>
<li><code>[pretty-format]</code> Fix errors when identity-obj-proxy mocks CSS Modules (<a href="https://renovatebot.com/gh/facebook/jest/pull/4935">#&#8203;4935</a>)</li>
<li><code>[babel-jest]</code> Fix support for namespaced babel version 7 (<a href="https://renovatebot.com/gh/facebook/jest/pull/4918">#&#8203;4918</a>)</li>
<li><code>[expect]</code> fix .toThrow for promises (<a href="https://renovatebot.com/gh/facebook/jest/pull/4884">#&#8203;4884</a>)</li>
<li><code>[jest-docblock]</code> pragmas should preserve urls (<a href="https://renovatebot.com/gh/facebook/jest/pull/4629">#&#8203;4837</a>)</li>
<li><code>[jest-cli]</code> Check if <code>npm_lifecycle_script</code> calls Jest directly (<a href="https://renovatebot.com/gh/facebook/jest/pull/4629">#&#8203;4629</a>)</li>
<li><code>[jest-cli]</code> Fix --showConfig to show all configs (<a href="https://renovatebot.com/gh/facebook/jest/pull/4494">#&#8203;4494</a>)</li>
<li><code>[jest-cli]</code> Throw if <code>maxWorkers</code> doesn't have a value (<a href="https://renovatebot.com/gh/facebook/jest/pull/4591">#&#8203;4591</a>)</li>
<li><code>[jest-cli]</code> Use <code>fs.realpathSync.native</code> if available (<a href="https://renovatebot.com/gh/facebook/jest/pull/5031">#&#8203;5031</a>)</li>
<li><code>[jest-config]</code> Fix <code>--passWithNoTests</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/4639">#&#8203;4639</a>)</li>
<li><code>[jest-config]</code> Support <code>rootDir</code> tag in testEnvironment (<a href="https://renovatebot.com/gh/facebook/jest/pull/4579">#&#8203;4579</a>)</li>
<li><code>[jest-editor-support]</code> Fix <code>--showConfig</code> to support jest 20 and jest 21 (<a href="https://renovatebot.com/gh/facebook/jest/pull/4575">#&#8203;4575</a>)</li>
<li><code>[jest-editor-support]</code> Fix editor support test for node 4 (<a href="https://renovatebot.com/gh/facebook/jest/pull/4640">#&#8203;4640</a>)</li>
<li><code>[jest-mock]</code> Support mocking constructor in <code>mockImplementationOnce</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/4599">#&#8203;4599</a>)</li>
<li><code>[jest-runtime]</code> Fix manual user mocks not working with custom resolver (<a href="https://renovatebot.com/gh/facebook/jest/pull/4489">#&#8203;4489</a>)</li>
<li><code>[jest-util]</code> Fix <code>runOnlyPendingTimers</code> for <code>setTimeout</code> inside <code>setImmediate</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/4608">#&#8203;4608</a>)</li>
<li><code>[jest-message-util]</code> Always remove node internals from stacktraces (<a href="https://renovatebot.com/gh/facebook/jest/pull/4695">#&#8203;4695</a>)</li>
<li><code>[jest-resolve]</code> changes method of determining builtin modules to include missing builtins (<a href="https://renovatebot.com/gh/facebook/jest/pull/4740">#&#8203;4740</a>)</li>
<li><code>[pretty-format]</code> Prevent error in pretty-format for window in jsdom test env (<a href="https://renovatebot.com/gh/facebook/jest/pull/4750">#&#8203;4750</a>)</li>
<li><code>[jest-resolve]</code> Preserve module identity for symlinks (<a href="https://renovatebot.com/gh/facebook/jest/pull/4761">#&#8203;4761</a>)</li>
<li><code>[jest-config]</code> Include error message for <code>preset</code> json (<a href="https://renovatebot.com/gh/facebook/jest/pull/4766">#&#8203;4766</a>)</li>
<li><code>[pretty-format]</code> Throw <code>PrettyFormatPluginError</code> if a plugin halts with an exception (<a href="https://renovatebot.com/gh/facebook/jest/pull/4787">#&#8203;4787</a>)</li>
<li><code>[expect]</code> Keep the stack trace unchanged when <code>PrettyFormatPluginError</code> is thrown by pretty-format (<a href="https://renovatebot.com/gh/facebook/jest/pull/4787">#&#8203;4787</a>)</li>
<li><code>[jest-environment-jsdom]</code> Fix asynchronous test will fail due to timeout issue. (<a href="https://renovatebot.com/gh/facebook/jest/pull/4669">#&#8203;4669</a>)</li>
<li><code>[jest-cli]</code> Fix <code>--onlyChanged</code> path case sensitivity on Windows platform (<a href="https://renovatebot.com/gh/facebook/jest/pull/4730">#&#8203;4730</a>)</li>
<li><code>[jest-runtime]</code> Use realpath to match transformers (<a href="https://renovatebot.com/gh/facebook/jest/pull/5000">#&#8203;5000</a>)</li>
<li><code>[expect]</code> [<strong>BREAKING</strong>] Replace identity equality with Object.is in toBe matcher (<a href="https://renovatebot.com/gh/facebook/jest/pull/4917">#&#8203;4917</a>)</li>
</ul>
<h5 id="features-10">Features</h5>
<ul>
<li><code>[jest-message-util]</code> Add codeframe to test assertion failures (<a href="https://renovatebot.com/gh/facebook/jest/pull/5087">#&#8203;5087</a>)</li>
<li><code>[jest-config]</code> Add Global Setup/Teardown options (<a href="https://renovatebot.com/gh/facebook/jest/pull/4716">#&#8203;4716</a>)</li>
<li><code>[jest-config]</code> Add <code>testEnvironmentOptions</code> to apply to jsdom options or node context. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5003">#&#8203;5003</a>)</li>
<li><code>[jest-jasmine2]</code> Update Timeout error message to <code>jest.timeout</code> and display current timeout value (<a href="https://renovatebot.com/gh/facebook/jest/pull/4990">#&#8203;4990</a>)</li>
<li><code>[jest-runner]</code> Enable experimental detection of leaked contexts (<a href="https://renovatebot.com/gh/facebook/jest/pull/4895">#&#8203;4895</a>)</li>
<li><code>[jest-cli]</code> Add combined coverage threshold for directories. (<a href="https://renovatebot.com/gh/facebook/jest/pull/4885">#&#8203;4885</a>)</li>
<li><code>[jest-mock]</code> Add <code>timestamps</code> to mock state. (<a href="https://renovatebot.com/gh/facebook/jest/pull/4866">#&#8203;4866</a>)</li>
<li><code>[eslint-plugin-jest]</code> Add <code>prefer-to-have-length</code> lint rule. (<a href="https://renovatebot.com/gh/facebook/jest/pull/4771">#&#8203;4771</a>)</li>
<li><code>[jest-environment-jsdom]</code> [<strong>BREAKING</strong>] Upgrade to JSDOM@&#8203;11 (<a href="https://renovatebot.com/gh/facebook/jest/pull/4770">#&#8203;4770</a>)</li>
<li><code>[jest-environment-*]</code> [<strong>BREAKING</strong>] Add Async Test Environment APIs, dispose is now teardown (<a href="https://renovatebot.com/gh/facebook/jest/pull/4506">#&#8203;4506</a>)</li>
<li><code>[jest-cli]</code> Add an option to clear the cache (<a href="https://renovatebot.com/gh/facebook/jest/pull/4430">#&#8203;4430</a>)</li>
<li><code>[babel-plugin-jest-hoist]</code> Improve error message, that the second argument of <code>jest.mock</code> must be an inline function (<a href="https://renovatebot.com/gh/facebook/jest/pull/4593">#&#8203;4593</a>)</li>
<li><code>[jest-snapshot]</code> [<strong>BREAKING</strong>] Concatenate name of test and snapshot (<a href="https://renovatebot.com/gh/facebook/jest/pull/4460">#&#8203;4460</a>)</li>
<li><code>[jest-cli]</code> [<strong>BREAKING</strong>] Fail if no tests are found (<a href="https://renovatebot.com/gh/facebook/jest/pull/3672">#&#8203;3672</a>)</li>
<li><code>[jest-diff]</code> Highlight only last of odd length leading spaces (<a href="https://renovatebot.com/gh/facebook/jest/pull/4558">#&#8203;4558</a>)</li>
<li><code>[jest-docblock]</code> Add <code>docblock.print()</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/4517">#&#8203;4517</a>)</li>
<li><code>[jest-docblock]</code> Add <code>strip</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/4571">#&#8203;4571</a>)</li>
<li><code>[jest-docblock]</code> Preserve leading whitespace in docblock comments (<a href="https://renovatebot.com/gh/facebook/jest/pull/4576">#&#8203;4576</a>)</li>
<li><code>[jest-docblock]</code> remove leading newlines from <code>parswWithComments().comments</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/4610">#&#8203;4610</a>)</li>
<li><code>[jest-editor-support]</code> Add Snapshots metadata (<a href="https://renovatebot.com/gh/facebook/jest/pull/4570">#&#8203;4570</a>)</li>
<li><code>[jest-editor-support]</code> Adds an 'any' to the typedef for <code>updateFileWithJestStatus</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/4636">#&#8203;4636</a>)</li>
<li><code>[jest-editor-support]</code> Better monorepo support (<a href="https://renovatebot.com/gh/facebook/jest/pull/4572">#&#8203;4572</a>)</li>
<li><code>[jest-environment-jsdom]</code> Add simple rAF polyfill in jsdom environment to work with React 16 (<a href="https://renovatebot.com/gh/facebook/jest/pull/4568">#&#8203;4568</a>)</li>
<li><code>[jest-environment-node]</code> Implement node Timer api (<a href="https://renovatebot.com/gh/facebook/jest/pull/4622">#&#8203;4622</a>)</li>
<li><code>[jest-jasmine2]</code> Add testPath to reporter callbacks (<a href="https://renovatebot.com/gh/facebook/jest/pull/4594">#&#8203;4594</a>)</li>
<li><code>[jest-mock]</code> Added support for naming mocked functions with <code>.mockName(value)</code> and <code>.mockGetName()</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/4586">#&#8203;4586</a>)</li>
<li><code>[jest-runtime]</code> Add <code>module.loaded</code>, and make <code>module.require</code> not enumerable (<a href="https://renovatebot.com/gh/facebook/jest/pull/4623">#&#8203;4623</a>)</li>
<li><code>[jest-runtime]</code> Add <code>module.parent</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/4614">#&#8203;4614</a>)</li>
<li><code>[jest-runtime]</code> Support sourcemaps in transformers (<a href="https://renovatebot.com/gh/facebook/jest/pull/3458">#&#8203;3458</a>)</li>
<li><code>[jest-snapshot]</code> [<strong>BREAKING</strong>] Add a serializer for <code>jest.fn</code> to allow a snapshot of a jest mock (<a href="https://renovatebot.com/gh/facebook/jest/pull/4668">#&#8203;4668</a>)</li>
<li><code>[jest-worker]</code> Initial version of parallel worker abstraction, say hello! (<a href="https://renovatebot.com/gh/facebook/jest/pull/4497">#&#8203;4497</a>)</li>
<li><code>[jest-jasmine2]</code> Add <code>testLocationInResults</code> flag to add location information per spec to test results (<a href="https://renovatebot.com/gh/facebook/jest/pull/4782">#&#8203;4782</a>)</li>
<li><code>[jest-environment-jsdom]</code> Update JSOM to 11.4, which includes built-in support for <code>requestAnimationFrame</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/4919">#&#8203;4919</a>)</li>
<li><code>[jest-cli]</code> Hide watch usage output when running on non-interactive environments (<a href="https://renovatebot.com/gh/facebook/jest/pull/4958">#&#8203;4958</a>)</li>
<li><code>[jest-snapshot]</code> Promises support for <code>toThrowErrorMatchingSnapshot</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/4946">#&#8203;4946</a>)</li>
<li><code>[jest-cli]</code> Explain which snapshots are obsolete (<a href="https://renovatebot.com/gh/facebook/jest/pull/5005">#&#8203;5005</a>)</li>
</ul>
<h5 id="chore--maintenance-11">Chore &amp; Maintenance</h5>
<ul>
<li><code>[docs]</code> Add guide of using with puppeteer (<a href="https://renovatebot.com/gh/facebook/jest/pull/5093">#&#8203;5093</a>)</li>
<li><code>[jest-util]</code> <code>jest-util</code> should not depend on <code>jest-mock</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/4992">#&#8203;4992</a>)</li>
<li><code>[*]</code> [<strong>BREAKING</strong>] Drop support for Node.js version 4 (<a href="https://renovatebot.com/gh/facebook/jest/pull/4769">#&#8203;4769</a>)</li>
<li><code>[docs]</code> Wrap code comments at 80 characters (<a href="https://renovatebot.com/gh/facebook/jest/pull/4781">#&#8203;4781</a>)</li>
<li><code>[eslint-plugin-jest]</code> Removed from the Jest core repo, and moved to <a href="https://renovatebot.com/gh/jest-community/eslint-plugin-jest">https://github.com/jest-community/eslint-plugin-jest</a> (<a href="https://renovatebot.com/gh/facebook/jest/pull/4867">#&#8203;4867</a>)</li>
<li><code>[babel-jest]</code> Explicitly bump istanbul to newer versions (<a href="https://renovatebot.com/gh/facebook/jest/pull/4616">#&#8203;4616</a>)</li>
<li><code>[expect]</code> Upgrade mocha and rollup for browser testing (<a href="https://renovatebot.com/gh/facebook/jest/pull/4642">#&#8203;4642</a>)</li>
<li><code>[docs]</code> Add info about <code>coveragePathIgnorePatterns</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/4602">#&#8203;4602</a>)</li>
<li><code>[docs]</code> Add Vuejs series of testing with Jest (<a href="https://renovatebot.com/gh/facebook/jest/pull/4648">#&#8203;4648</a>)</li>
<li><code>[docs]</code> Mention about optional <code>done</code> argument in test function (<a href="https://renovatebot.com/gh/facebook/jest/pull/4556">#&#8203;4556</a>)</li>
<li><code>[jest-cli]</code> Bump node-notifier version (<a href="https://renovatebot.com/gh/facebook/jest/pull/4609">#&#8203;4609</a>)</li>
<li><code>[jest-diff]</code> Simplify highlight for leading and trailing spaces (<a href="https://renovatebot.com/gh/facebook/jest/pull/4553">#&#8203;4553</a>)</li>
<li><code>[jest-get-type]</code> Add support for date (<a href="https://renovatebot.com/gh/facebook/jest/pull/4621">#&#8203;4621</a>)</li>
<li><code>[jest-matcher-utils]</code> Call <code>chalk.inverse</code> for trailing spaces (<a href="https://renovatebot.com/gh/facebook/jest/pull/4578">#&#8203;4578</a>)</li>
<li><code>[jest-runtime]</code> Add <code>.advanceTimersByTime</code>; keep <code>.runTimersToTime()</code> as an alias.</li>
<li><code>[docs]</code> Include missing dependency in TestEnvironment sample code</li>
<li><code>[docs]</code> Add clarification for hook execution order</li>
<li><code>[docs]</code> Update <code>expect.anything()</code> sample code (<a href="https://renovatebot.com/gh/facebook/jest/pull/5007">#&#8203;5007</a>)</li>
</ul>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>