### PR TITLE
chore(deps): update dependency rxjs to v5.5.11 - autoclosed

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "@dcos/copychars": "0.1.2",
     "@dcos/http-service": "0.3.0",
     "@dcos/recordio": "0.1.7",
-    "rxjs": "5.4.3"
+    "rxjs": "5.5.11"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3652,6 +3652,12 @@ rxjs@5.4.3:
   dependencies:
     symbol-observable "^1.0.1"
 
+rxjs@5.5.11:
+  version "5.5.11"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.11.tgz#f733027ca43e3bec6b994473be4ab98ad43ced87"
+  dependencies:
+    symbol-observable "1.0.1"
+
 safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
@@ -3958,6 +3964,10 @@ supports-color@^5.3.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.4.0.tgz#1c6b337402c2137605efe19f10fec390f6faab54"
   dependencies:
     has-flag "^3.0.0"
+
+symbol-observable@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
 
 symbol-observable@^1.0.1:
   version "1.0.4"


### PR DESCRIPTION
<p>This Pull Request updates dependency <a href="https://renovatebot.com/gh/reactivex/rxjs">rxjs</a> from <code>v5.4.3</code> to <code>v5.5.11</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v5511httpsgithubcomreactivexrxjscompare55105511"><a href="https://renovatebot.com/gh/reactivex/rxjs/compare/5.5.10…5.5.11"><code>v5.5.11</code></a></h3>
<p><a href="https://renovatebot.com/gh/reactivex/rxjs/compare/5.5.10…5.5.11">Compare Source</a></p>
<hr />
<h3 id="v5510httpsgithubcomreactivexrxjscompare5595510"><a href="https://renovatebot.com/gh/reactivex/rxjs/compare/5.5.9…5.5.10"><code>v5.5.10</code></a></h3>
<p><a href="https://renovatebot.com/gh/reactivex/rxjs/compare/5.5.9…5.5.10">Compare Source</a></p>
<hr />
<h3 id="v559httpsgithubcomreactivexrxjscompare558559"><a href="https://renovatebot.com/gh/reactivex/rxjs/compare/5.5.8…5.5.9"><code>v5.5.9</code></a></h3>
<p><a href="https://renovatebot.com/gh/reactivex/rxjs/compare/5.5.8…5.5.9">Compare Source</a></p>
<hr />
<h3 id="v558httpsgithubcomreactivexrxjscompare557558"><a href="https://renovatebot.com/gh/reactivex/rxjs/compare/5.5.7…5.5.8"><code>v5.5.8</code></a></h3>
<p><a href="https://renovatebot.com/gh/reactivex/rxjs/compare/5.5.7…5.5.8">Compare Source</a></p>
<hr />
<h3 id="v557httpsgithubcomreactivexrxjscompare556557"><a href="https://renovatebot.com/gh/reactivex/rxjs/compare/5.5.6…5.5.7"><code>v5.5.7</code></a></h3>
<p><a href="https://renovatebot.com/gh/reactivex/rxjs/compare/5.5.6…5.5.7">Compare Source</a></p>
<hr />
<h3 id="v556httpsgithubcomreactivexrxjsblobmasterchangelogmd8203556httpsgithubcomreactivexrxjscompare555v556-2017-12-21"><a href="https://renovatebot.com/gh/reactivex/rxjs/blob/master/CHANGELOG.md#&#8203;556httpsgithubcomReactiveXRxJScompare555v556-2017-12-21"><code>v5.5.6</code></a></h3>
<p><a href="https://renovatebot.com/gh/reactivex/rxjs/compare/5.5.5…5.5.6">Compare Source</a></p>
<h5 id="bug-fixes">Bug Fixes</h5>
<ul>
<li><strong>Observable:</strong> rethrow errors when syncErrorThrowable and inherit it from destination. Fixes <a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/2813">#&#8203;2813</a> (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/541b49d">541b49d</a>)</li>
</ul>
<hr />
<h3 id="v555httpsgithubcomreactivexrxjsblobmasterchangelogmd8203556httpsgithubcomreactivexrxjscompare555v556-2017-12-21"><a href="https://renovatebot.com/gh/reactivex/rxjs/blob/master/CHANGELOG.md#&#8203;556httpsgithubcomReactiveXRxJScompare555v556-2017-12-21"><code>v5.5.5</code></a></h3>
<p><a href="https://renovatebot.com/gh/reactivex/rxjs/compare/5.5.4…5.5.5">Compare Source</a></p>
<h5 id="bug-fixes-1">Bug Fixes</h5>
<ul>
<li><strong>Observable:</strong> rethrow errors when syncErrorThrowable and inherit it from destination. Fixes <a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/2813">#&#8203;2813</a> (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/541b49d">541b49d</a>)</li>
</ul>
<hr />
<h3 id="v554httpsgithubcomreactivexrxjsblobmasterchangelogmd8203555httpsgithubcomreactivexrxjscompare554v555-2017-12-06"><a href="https://renovatebot.com/gh/reactivex/rxjs/blob/master/CHANGELOG.md#&#8203;555httpsgithubcomReactiveXRxJScompare554v555-2017-12-06"><code>v5.5.4</code></a></h3>
<p><a href="https://renovatebot.com/gh/reactivex/rxjs/compare/5.5.3…5.5.4">Compare Source</a></p>
<h5 id="support-added">Support Added</h5>
<ul>
<li><strong>Bazel:</strong> Add files to support users that want Bazel builds with RxJS (<a href="https://renovatebot.com/gh/ReactiveX/rxjs/commit/12dac3b">12dac3b</a>)</li>
</ul>
<hr />
<h3 id="v553httpsgithubcomreactivexrxjsblobmasterchangelogmd8203600-alpha1httpsgithubcomreactivexrxjscompare553v600-alpha1-2018-01-12"><a href="https://renovatebot.com/gh/reactivex/rxjs/blob/master/CHANGELOG.md#&#8203;600-alpha1httpsgithubcomReactiveXRxJScompare553v600-alpha1-2018-01-12"><code>v5.5.3</code></a></h3>
<p><a href="https://renovatebot.com/gh/reactivex/rxjs/compare/5.5.2…5.5.3">Compare Source</a></p>
<h5 id="bug-fixes-2">Bug Fixes</h5>
<ul>
<li>Revert "fix(scheduler): prevent unwanted clearInterval (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/3044">#&#8203;3044</a>)" (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/ad5c7c6">ad5c7c6</a>)</li>
<li>Revert "fix(scheduler): prevent unwanted clearInterval (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/3044">#&#8203;3044</a>)" (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/64f9285">64f9285</a>)</li>
<li><strong>debounceTime:</strong> synchronous reentrancy of debounceTime no longer swallows the second value (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/3218">#&#8203;3218</a>) (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/598e9ce">598e9ce</a>), closes <a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/2748">#&#8203;2748</a></li>
<li><strong>dependency:</strong> move symbol-observable into devdependency (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/4400628">4400628</a>)</li>
<li><strong>IteratorObservable:</strong> get new iterator for each subscription (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/2497">#&#8203;2497</a>) (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/1bd0a58">1bd0a58</a>), closes <a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/2496">#&#8203;2496</a></li>
<li><strong>Observable.toArray:</strong> Fix toArray with multiple subscriptions. (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/3134">#&#8203;3134</a>) (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/3390926">3390926</a>)</li>
<li><strong>SystemJS:</strong> avoid node module resolution of pipeable operators (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/3025">#&#8203;3025</a>) (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/0f3cf71">0f3cf71</a>), closes <a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/2971">#&#8203;2971</a> <a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/2996">#&#8203;2996</a> <a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/3011">#&#8203;3011</a></li>
<li><strong>tap:</strong> make next optional (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/3073">#&#8203;3073</a>) (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/e659f0c">e659f0c</a>), closes <a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/2534">#&#8203;2534</a></li>
<li><strong>TSC:</strong> Fixing TSC errors. Fixes <a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/3020">#&#8203;3020</a> (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/01d1575">01d1575</a>)</li>
<li><strong>typings:</strong> the return type of project of mergeScan should be ObservableInput<R> (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/23fe17d">23fe17d</a>)</li>
</ul>
<h5 id="chores">Chores</h5>
<ul>
<li><strong>TypeScript:</strong> Bump up typescript to latest (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/3009">#&#8203;3009</a>) (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/2f395da">2f395da</a>)</li>
</ul>
<h5 id="code-refactoring">Code Refactoring</h5>
<ul>
<li><strong>asap:</strong> Remove setImmediate polyfill (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/5eb6af7">5eb6af7</a>)</li>
<li><strong>distinct:</strong> Remove Set polyfill (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/68ee499">68ee499</a>)</li>
<li><strong>groupBy:</strong> Remove Map polyfill (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/74b5b1a">74b5b1a</a>)</li>
</ul>
<h5 id="features">Features</h5>
<ul>
<li><strong>Observable:</strong> unhandled errors are now reported to HostReportErrors (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/3062">#&#8203;3062</a>) (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/cd9626a">cd9626a</a>)</li>
<li><strong>reorganize:</strong> move ./interfaces.ts to internal/types.ts (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/cfbfaac">cfbfaac</a>)</li>
<li><strong>reorganize:</strong> internal utils hidden (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/70058cd">70058cd</a>)</li>
<li><strong>reorganize:</strong> add <code>rxjs/create</code> exports (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/c9963bd">c9963bd</a>)</li>
<li><strong>reorganize:</strong> ajax observable creator now exported from <code>rxjs/ajax</code> (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/e971c93">e971c93</a>)</li>
<li><strong>reorganize:</strong> all patch operators moved to <code>internal</code> directory (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/7342401">7342401</a>)</li>
<li><strong>reorganize:</strong> export <code>noop</code> and <code>identity</code> from <code>rxjs</code> (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/810c4d0">810c4d0</a>)</li>
<li><strong>reorganize:</strong> export <code>Notification</code> from <code>rxjs</code> (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/8809b48">8809b48</a>)</li>
<li><strong>reorganize:</strong> export schedulers from <code>rxjs</code> (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/abd3b61">abd3b61</a>)</li>
<li><strong>reorganize:</strong> export Subject, ReplaySubject, BehaviorSubject from rxjs (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/bd683ca">bd683ca</a>)</li>
<li><strong>reorganize:</strong> export the <code>pipe</code> utility function from <code>rxjs</code> (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/4574310">4574310</a>)</li>
<li><strong>reorganize:</strong> hid testing implementation details (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/b981666">b981666</a>)</li>
<li><strong>reorganize:</strong> move observable implementations under internal directory (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/2d5c3f8">2d5c3f8</a>)</li>
<li><strong>reorganize:</strong> move operator impls under internal directory (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/207976f">207976f</a>)</li>
<li><strong>reorganize:</strong> move top-level impls under internal directory (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/c3bb705">c3bb705</a>)</li>
<li><strong>reorganize:</strong> moved symbols to be internal (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/80783ab">80783ab</a>)</li>
<li><strong>reorganize:</strong> operators all exported from <code>rxjs/operators</code> (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/b1f8bfe">b1f8bfe</a>)</li>
<li><strong>reorganize:</strong> websocket subject creator now exported from <code>rxjs/websocket</code> (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/5ac62c0">5ac62c0</a>)</li>
</ul>
<h5 id="breaking-changes">BREAKING CHANGES</h5>
<ul>
<li><strong>webSocket:</strong> <code>webSocket</code> creator function now exported from <code>rxjs/websocket</code> as <code>websocket</code>.</li>
<li><strong>IteratorObservable:</strong> IteratorObservable no longer share iterator between<br />
subscription</li>
<li><strong>utils:</strong> Many internal use utilities like <code>isArray</code> are now hidden under <code>rxjs/internal</code>, they are implementation details and should not be used.</li>
<li><strong>testing observables:</strong> <code>HotObservable</code> and <code>ColdObservable</code>, and other testing support types are no longer exported directly.</li>
<li><strong>creation functions:</strong> All create functions such as <code>of</code>, <code>from</code>, <code>combineLatest</code> and <code>fromEvent</code> should now be imported from <code>rxjs/create</code>.</li>
<li><strong>types and interfaces:</strong> Can no longer explicitly import types from <code>rxjs/interfaces</code>, import them from <code>rxjs</code> instead</li>
<li><strong>symbols:</strong> Symbols are no longer exported directly from modules such as <code>rxjs/symbol/observable</code> please use <code>Symbol.observable</code> and <code>Symbol.iterator</code> (polyfills may be required)</li>
<li><strong>deep imports:</strong> Can no longer deep import top-level types such as <code>rxjs/Observable</code>, <code>rxjs/Subject</code>, <code>rxjs/ReplaySubject</code>, et al. All imports should be done directly from <code>rxjs</code>, for example: <code>import \{ Observable, Subject \} from 'rxjs';</code></li>
<li><strong>schedulers:</strong> Scheduler instances have changed names to be suffixed with <code>Scheduler</code>, (e.g. <code>asap</code> -&gt; <code>asapScheduler</code>)</li>
<li><strong>operators:</strong> Pipeable operators must now be imported from <code>rxjs</code><br />
like so: <code>import { map, filter, switchMap } from 'rxjs/operators';</code>. No deep imports.</li>
<li><strong>ajax:</strong> Ajax observable should be imported from <code>rxjs/ajax</code>.</li>
<li><strong>Observable:</strong> You should no longer deep import custom Observable<br />
implementations such as <code>ArrayObservable</code> or <code>ForkJoinObservable</code>.</li>
<li><strong>_throw:</strong> <code>_throw</code> is now exported as <code>throwError</code></li>
<li><strong>if:</strong> <code>if</code> is now exported as <code>iif</code></li>
<li><strong>operators:</strong> Deep imports to <code>rxjs/operator/*</code> will no longer work. Again, pipe operators are still where they were.</li>
<li><strong>error handling:</strong> Unhandled errors are no longer caught and rethrown, rather they are caught and scheduled to be thrown, which causes them to be reported to window.onerror or process.on('error'), depending on the environment. Consequently, teardown after a synchronous, unhandled, error will no longer occur, as the teardown would not exist, and producer interference cannot occur</li>
<li><strong>distinct:</strong> Using <code>distinct</code> requires a <code>Set</code> implementation and must be polyfilled in older runtimes</li>
<li><strong>asap:</strong> Old runtimes must polyfill Promise in order to use ASAP scheduling.</li>
<li><strong>groupBy:</strong> Older runtimes will require Map to be polyfilled to use<br />
<code>groupBy</code></li>
<li><strong>TypeScript:</strong> IE10 and lower will need to polyfill <code>Object.setPrototypeOf</code></li>
<li><strong>operators removed:</strong> Operator versions of static observable creators such as<br />
<code>merge</code>, <code>concat</code>, <code>zip</code>, <code>onErrorResumeNext</code>, and <code>race</code> have been<br />
removed. Please use the static versions of those operations. e.g.<br />
<code>a.pipe(concat(b, c))</code> becomes <code>concat(a, b, c)</code>.</li>
</ul>
<h4 id="556httpsgithubcomreactivexrxjscompare555v556-2017-12-21"><a href="https://renovatebot.com/gh/ReactiveX/RxJS/compare/5.5.5…v5.5.6">5.5.6</a> (2017-12-21)</h4>
<h5 id="bug-fixes-3">Bug Fixes</h5>
<ul>
<li><strong>Observable:</strong> rethrow errors when syncErrorThrowable and inherit it from destination. Fixes <a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/2813">#&#8203;2813</a> (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/541b49d">541b49d</a>)</li>
</ul>
<h4 id="555httpsgithubcomreactivexrxjscompare554v555-2017-12-06"><a href="https://renovatebot.com/gh/ReactiveX/RxJS/compare/5.5.4…v5.5.5">5.5.5</a> (2017-12-06)</h4>
<h5 id="support-added-1">Support Added</h5>
<ul>
<li><strong>Bazel:</strong> Add files to support users that want Bazel builds with RxJS (<a href="https://renovatebot.com/gh/ReactiveX/rxjs/commit/12dac3b">12dac3b</a>)</li>
</ul>
<h4 id="554httpsgithubcomreactivexrxjscompare553v554-2017-12-05"><a href="https://renovatebot.com/gh/ReactiveX/RxJS/compare/5.5.3…v5.5.4">5.5.4</a> (2017-12-05)</h4>
<h5 id="bug-fixes-4">Bug Fixes</h5>
<ul>
<li><strong>scheduler:</strong> resolve regression on angular router with zones (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/3158">#&#8203;3158</a>) (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/520b06a">520b06a</a>)</li>
<li><strong>publish:</strong> re-publish after having built with proper version of TypeScript. (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/f0ff5bc">f0ff5bc</a>, closes<a href="https://renovatebot.com/gh/ReactiveX/rxjs/issues/3155">#&#8203;3155</a>)</li>
</ul>
<h4 id="553httpsgithubcomreactivexrxjscompare552v553-2017-12-01"><a href="https://renovatebot.com/gh/ReactiveX/RxJS/compare/5.5.2…v5.5.3">5.5.3</a> (2017-12-01)</h4>
<h5 id="bug-fixes-5">Bug Fixes</h5>
<ul>
<li><strong>concatStatic:</strong> missing exports for mergeStatic and concatStatic (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/2999">#&#8203;2999</a>) (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/cae5f9b">cae5f9b</a>)</li>
<li><strong>scheduler:</strong> prevent unwanted clearInterval (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/3044">#&#8203;3044</a>) (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/7d722d4">7d722d4</a>), closes <a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/3042">#&#8203;3042</a></li>
<li><strong>SystemJS:</strong> avoid node module resolution of pipeable operators (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/3025">#&#8203;3025</a>) (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/d77e3d7">d77e3d7</a>), closes <a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/2971">#&#8203;2971</a> <a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/2996">#&#8203;2996</a> <a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/3011">#&#8203;3011</a></li>
<li><strong>typings:</strong> fix subscribe overloads (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/3053">#&#8203;3053</a>) (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/1a9fd42">1a9fd42</a>), closes <a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/3052">#&#8203;3052</a></li>
</ul>
<h4 id="552httpsgithubcomreactivexrxjscompare551v552-2017-10-25"><a href="https://renovatebot.com/gh/ReactiveX/RxJS/compare/5.5.1…v5.5.2">5.5.2</a> (2017-10-25)</h4>
<h5 id="bug-fixes-6">Bug Fixes</h5>
<ul>
<li><strong>package:</strong> fixed import failures in Webpack (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/2987">#&#8203;2987</a>) (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/e16202d">e16202d</a>)</li>
<li><strong>typings:</strong> improved type inference for arguments to publishReplay (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/2992">#&#8203;2992</a>) (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/0753ff7">0753ff7</a>), closes <a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/2991">#&#8203;2991</a></li>
<li><strong>typings:</strong> ensure TS types for <code>zip</code> and <code>combineLatest</code> are properly inferred. (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/b8e6cf8">b8e6cf8</a>)</li>
<li><strong>typings:</strong> publish variants will properly return ConnectableObservable(<a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/2983">#&#8203;2983</a>) (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/d563bfa">d563bfa</a>)</li>
</ul>
<h4 id="551httpsgithubcomreactivexrxjscompare550v551-2017-10-24"><a href="https://renovatebot.com/gh/ReactiveX/RxJS/compare/5.5.0…v5.5.1">5.5.1</a> (2017-10-24)</h4>
<h5 id="bug-fixes-7">Bug Fixes</h5>
<ul>
<li><strong>build:</strong> Remove <code>module</code> and <code>es2015</code> keys to avoid resolution conflicts (<a href="https:/github.com/ReactiveX/RxJS/commit/5073139">5073139</a>)</li>
<li><strong>ajaxobservable:</strong> fix operator import path (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/d9b62ed">d9b62ed</a>)</li>
</ul>
<hr />
<h3 id="v552httpsgithubcomreactivexrxjsblobmasterchangelogmd8203553httpsgithubcomreactivexrxjscompare552v553-2017-12-01"><a href="https://renovatebot.com/gh/reactivex/rxjs/blob/master/CHANGELOG.md#&#8203;553httpsgithubcomReactiveXRxJScompare552v553-2017-12-01"><code>v5.5.2</code></a></h3>
<p><a href="https://renovatebot.com/gh/reactivex/rxjs/compare/5.5.1…5.5.2">Compare Source</a></p>
<h5 id="bug-fixes-8">Bug Fixes</h5>
<ul>
<li><strong>concatStatic:</strong> missing exports for mergeStatic and concatStatic (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/2999">#&#8203;2999</a>) (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/cae5f9b">cae5f9b</a>)</li>
<li><strong>scheduler:</strong> prevent unwanted clearInterval (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/3044">#&#8203;3044</a>) (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/7d722d4">7d722d4</a>), closes <a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/3042">#&#8203;3042</a></li>
<li><strong>SystemJS:</strong> avoid node module resolution of pipeable operators (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/3025">#&#8203;3025</a>) (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/d77e3d7">d77e3d7</a>), closes <a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/2971">#&#8203;2971</a> <a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/2996">#&#8203;2996</a> <a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/3011">#&#8203;3011</a></li>
<li><strong>typings:</strong> fix subscribe overloads (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/3053">#&#8203;3053</a>) (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/1a9fd42">1a9fd42</a>), closes <a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/3052">#&#8203;3052</a></li>
</ul>
<hr />
<h3 id="v551httpsgithubcomreactivexrxjsblobmasterchangelogmd8203552httpsgithubcomreactivexrxjscompare551v552-2017-10-25"><a href="https://renovatebot.com/gh/reactivex/rxjs/blob/master/CHANGELOG.md#&#8203;552httpsgithubcomReactiveXRxJScompare551v552-2017-10-25"><code>v5.5.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/reactivex/rxjs/compare/5.5.0…5.5.1">Compare Source</a></p>
<h5 id="bug-fixes-9">Bug Fixes</h5>
<ul>
<li><strong>package:</strong> fixed import failures in Webpack (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/2987">#&#8203;2987</a>) (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/e16202d">e16202d</a>)</li>
<li><strong>typings:</strong> improved type inference for arguments to publishReplay (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/2992">#&#8203;2992</a>) (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/0753ff7">0753ff7</a>), closes <a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/2991">#&#8203;2991</a></li>
<li><strong>typings:</strong> ensure TS types for <code>zip</code> and <code>combineLatest</code> are properly inferred. (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/b8e6cf8">b8e6cf8</a>)</li>
<li><strong>typings:</strong> publish variants will properly return ConnectableObservable(<a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/2983">#&#8203;2983</a>) (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/d563bfa">d563bfa</a>)</li>
</ul>
<hr />
<h3 id="v550httpsgithubcomreactivexrxjsblobmasterchangelogmd8203550httpsgithubcomreactivexrxjscompare550-beta7v550-2017-10-18"><a href="https://renovatebot.com/gh/reactivex/rxjs/blob/master/CHANGELOG.md#&#8203;550httpsgithubcomReactiveXRxJScompare550-beta7v550-2017-10-18"><code>v5.5.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/reactivex/rxjs/compare/5.4.3…5.5.0">Compare Source</a></p>
<h5 id="bug-fixes-10">Bug Fixes</h5>
<ul>
<li><strong>build:</strong> CJS sourceMaps now inlined into sourcesContent (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/39b4af5">39b4af5</a>), closes <a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/2934">#&#8203;2934</a></li>
</ul>
<h5 id="features-1">Features</h5>
<ul>
<li><strong>publishReplay:</strong> add selector function to publishReplay (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/issues/2885">#&#8203;2885</a>) (<a href="https://renovatebot.com/gh/ReactiveX/RxJS/commit/e0efd13">e0efd13</a>)</li>
</ul>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>