### PR TITLE
chore(deps): update dependency jest to v23 - autoclosed

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "babel-cli": "^6.26.0",
     "babel-jest": "^21.2.0",
     "babel-preset-env": "^1.6.1",
-    "jest": "^21.2.1",
+    "jest": "^23.0.0",
     "jest-cli": "^22.0.0"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,7 +45,7 @@
   dependencies:
     "@dcos/copychars" "^0.1.2"
 
-abab@^1.0.3, abab@^1.0.4:
+abab@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
 
@@ -53,21 +53,11 @@ abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
 
-acorn-globals@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-3.1.0.tgz#fd8270f71fbb4996b004fa880ee5d46573a731bf"
-  dependencies:
-    acorn "^4.0.4"
-
 acorn-globals@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-4.1.0.tgz#ab716025dbe17c54d3ef81d32ece2b2d99fe2538"
   dependencies:
     acorn "^5.0.0"
-
-acorn@^4.0.4:
-  version "4.0.13"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
 acorn@^5.0.0, acorn@^5.3.0:
   version "5.5.3"
@@ -432,6 +422,13 @@ babel-jest@^22.4.3:
     babel-plugin-istanbul "^4.1.5"
     babel-preset-jest "^22.4.3"
 
+babel-jest@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-23.4.2.tgz#f276de67798a5d68f2d6e87ff518c2f6e1609877"
+  dependencies:
+    babel-plugin-istanbul "^4.1.6"
+    babel-preset-jest "^23.2.0"
+
 babel-messages@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
@@ -452,7 +449,7 @@ babel-plugin-istanbul@^4.0.0:
     istanbul-lib-instrument "^1.7.5"
     test-exclude "^4.1.1"
 
-babel-plugin-istanbul@^4.1.5:
+babel-plugin-istanbul@^4.1.5, babel-plugin-istanbul@^4.1.6:
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"
   dependencies:
@@ -468,6 +465,10 @@ babel-plugin-jest-hoist@^21.2.0:
 babel-plugin-jest-hoist@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.3.tgz#7d8bcccadc2667f96a0dcc6afe1891875ee6c14a"
+
+babel-plugin-jest-hoist@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz#e61fae05a1ca8801aadee57a6d66b8cefaf44167"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -739,6 +740,13 @@ babel-preset-jest@^22.4.3:
     babel-plugin-jest-hoist "^22.4.3"
     babel-plugin-syntax-object-rest-spread "^6.13.0"
 
+babel-preset-jest@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz#8ec7a03a138f001a1a8fb1e8113652bf1a55da46"
+  dependencies:
+    babel-plugin-jest-hoist "^23.2.0"
+    babel-plugin-syntax-object-rest-spread "^6.13.0"
+
 babel-register@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.26.0.tgz#6ed021173e2fcb486d7acb45c6009a856f647071"
@@ -768,7 +776,7 @@ babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0:
     babylon "^6.18.0"
     lodash "^4.17.4"
 
-babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
+babel-traverse@^6.0.0, babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-6.26.0.tgz#46a9cbd7edcc62c8e5c064e2d2d8d0f4035766ee"
   dependencies:
@@ -782,7 +790,7 @@ babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
     invariant "^2.2.2"
     lodash "^4.17.4"
 
-babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
+babel-types@^6.0.0, babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
   dependencies:
@@ -882,6 +890,12 @@ browser-process-hrtime@^0.1.2:
 browser-resolve@^1.11.2:
   version "1.11.2"
   resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.2.tgz#8ff09b0a2c421718a1051c260b32e48f442938ce"
+  dependencies:
+    resolve "1.1.7"
+
+browser-resolve@^1.11.3:
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/browser-resolve/-/browser-resolve-1.11.3.tgz#9b7cbb3d0f510e4cb86bdbd796124d28b5890af6"
   dependencies:
     resolve "1.1.7"
 
@@ -1009,14 +1023,6 @@ cliui@^2.1.0:
     right-align "^0.1.1"
     wordwrap "0.0.2"
 
-cliui@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/cliui/-/cliui-3.2.0.tgz#120601537a916d29940f934da3b48d585a39213d"
-  dependencies:
-    string-width "^1.0.1"
-    strip-ansi "^3.0.1"
-    wrap-ansi "^2.0.0"
-
 cliui@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-4.1.0.tgz#348422dbe82d800b3022eef4f6ac10bf2e4d1b49"
@@ -1075,10 +1081,6 @@ concat-map@0.0.1:
 console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
-
-content-type-parser@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/content-type-parser/-/content-type-parser-1.0.2.tgz#caabe80623e63638b2502fd4c7f12ff4ce2352e7"
 
 convert-source-map@^1.4.0, convert-source-map@^1.5.0:
   version "1.5.0"
@@ -1238,12 +1240,6 @@ electron-to-chromium@^1.3.24:
   version "1.3.27"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz#78ecb8a399066187bb374eede35d9c70565a803d"
 
-errno@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/errno/-/errno-0.1.4.tgz#b896e23a9e5e8ba33871fc996abd3635fc9a1c7d"
-  dependencies:
-    prr "~0.0.0"
-
 error-ex@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/error-ex/-/error-ex-1.3.1.tgz#f855a86ce61adc4e8621c3cda21e7a7612c3a8dc"
@@ -1271,17 +1267,6 @@ es-to-primitive@^1.1.1:
 escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
-
-escodegen@^1.6.1:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.9.0.tgz#9811a2f265dc1cd3894420ee3717064b632b8852"
-  dependencies:
-    esprima "^3.1.3"
-    estraverse "^4.2.0"
-    esutils "^2.0.2"
-    optionator "^0.8.1"
-  optionalDependencies:
-    source-map "~0.5.6"
 
 escodegen@^1.9.0:
   version "1.9.1"
@@ -1356,17 +1341,6 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
-expect@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-21.2.1.tgz#003ac2ac7005c3c29e73b38a272d4afadd6d1d7b"
-  dependencies:
-    ansi-styles "^3.2.0"
-    jest-diff "^21.2.1"
-    jest-get-type "^21.2.0"
-    jest-matcher-utils "^21.2.1"
-    jest-message-util "^21.2.1"
-    jest-regex-util "^21.2.0"
-
 expect@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/expect/-/expect-22.4.3.tgz#d5a29d0a0e1fb2153557caef2674d4547e914674"
@@ -1377,6 +1351,17 @@ expect@^22.4.3:
     jest-matcher-utils "^22.4.3"
     jest-message-util "^22.4.3"
     jest-regex-util "^22.4.3"
+
+expect@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-23.4.0.tgz#6da4ecc99c1471253e7288338983ad1ebadb60c3"
+  dependencies:
+    ansi-styles "^3.2.0"
+    jest-diff "^23.2.0"
+    jest-get-type "^22.1.0"
+    jest-matcher-utils "^23.2.0"
+    jest-message-util "^23.4.0"
+    jest-regex-util "^23.3.0"
 
 extend-shallow@^2.0.1:
   version "2.0.1"
@@ -1473,7 +1458,7 @@ find-up@^1.0.0:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
 
-find-up@^2.0.0, find-up@^2.1.0:
+find-up@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
   dependencies:
@@ -1746,7 +1731,7 @@ hosted-git-info@^2.1.4:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
 
-html-encoding-sniffer@^1.0.1, html-encoding-sniffer@^1.0.2:
+html-encoding-sniffer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"
   dependencies:
@@ -2024,23 +2009,7 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
-istanbul-api@^1.1.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/istanbul-api/-/istanbul-api-1.2.1.tgz#0c60a0515eb11c7d65c6b50bba2c6e999acd8620"
-  dependencies:
-    async "^2.1.4"
-    fileset "^2.0.2"
-    istanbul-lib-coverage "^1.1.1"
-    istanbul-lib-hook "^1.1.0"
-    istanbul-lib-instrument "^1.9.1"
-    istanbul-lib-report "^1.1.2"
-    istanbul-lib-source-maps "^1.2.2"
-    istanbul-reports "^1.1.3"
-    js-yaml "^3.7.0"
-    mkdirp "^0.5.1"
-    once "^1.4.0"
-
-istanbul-api@^1.1.14:
+istanbul-api@^1.1.14, istanbul-api@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/istanbul-api/-/istanbul-api-1.3.1.tgz#4c3b05d18c0016d1022e079b98dc82c40f488954"
   dependencies:
@@ -2057,19 +2026,13 @@ istanbul-api@^1.1.14:
     mkdirp "^0.5.1"
     once "^1.4.0"
 
-istanbul-lib-coverage@^1.0.1, istanbul-lib-coverage@^1.1.1:
+istanbul-lib-coverage@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.1.tgz#73bfb998885299415c93d38a3e9adf784a77a9da"
 
 istanbul-lib-coverage@^1.1.2, istanbul-lib-coverage@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz#f7d8f2e42b97e37fe796114cb0f9d68b5e3a4341"
-
-istanbul-lib-hook@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz#8538d970372cb3716d53e55523dd54b557a8d89b"
-  dependencies:
-    append-transform "^0.4.0"
 
 istanbul-lib-hook@^1.2.0:
   version "1.2.0"
@@ -2089,7 +2052,7 @@ istanbul-lib-instrument@^1.10.1, istanbul-lib-instrument@^1.8.0:
     istanbul-lib-coverage "^1.2.0"
     semver "^5.3.0"
 
-istanbul-lib-instrument@^1.4.2, istanbul-lib-instrument@^1.7.5, istanbul-lib-instrument@^1.9.1:
+istanbul-lib-instrument@^1.7.5:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.9.1.tgz#250b30b3531e5d3251299fdd64b0b2c9db6b558e"
   dependencies:
@@ -2101,15 +2064,6 @@ istanbul-lib-instrument@^1.4.2, istanbul-lib-instrument@^1.7.5, istanbul-lib-ins
     istanbul-lib-coverage "^1.1.1"
     semver "^5.3.0"
 
-istanbul-lib-report@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.2.tgz#922be27c13b9511b979bd1587359f69798c1d425"
-  dependencies:
-    istanbul-lib-coverage "^1.1.1"
-    mkdirp "^0.5.1"
-    path-parse "^1.0.5"
-    supports-color "^3.1.2"
-
 istanbul-lib-report@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/istanbul-lib-report/-/istanbul-lib-report-1.1.4.tgz#e886cdf505c4ebbd8e099e4396a90d0a28e2acb5"
@@ -2118,16 +2072,6 @@ istanbul-lib-report@^1.1.4:
     mkdirp "^0.5.1"
     path-parse "^1.0.5"
     supports-color "^3.1.2"
-
-istanbul-lib-source-maps@^1.1.0, istanbul-lib-source-maps@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.2.tgz#750578602435f28a0c04ee6d7d9e0f2960e62c1c"
-  dependencies:
-    debug "^3.1.0"
-    istanbul-lib-coverage "^1.1.1"
-    mkdirp "^0.5.1"
-    rimraf "^2.6.1"
-    source-map "^0.5.3"
 
 istanbul-lib-source-maps@^1.2.1:
   version "1.2.3"
@@ -2149,23 +2093,11 @@ istanbul-lib-source-maps@^1.2.4:
     rimraf "^2.6.1"
     source-map "^0.5.3"
 
-istanbul-reports@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.1.3.tgz#3b9e1e8defb6d18b1d425da8e8b32c5a163f2d10"
-  dependencies:
-    handlebars "^4.0.3"
-
 istanbul-reports@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/istanbul-reports/-/istanbul-reports-1.3.0.tgz#2f322e81e1d9520767597dca3c20a0cce89a3554"
   dependencies:
     handlebars "^4.0.3"
-
-jest-changed-files@^21.2.0:
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-21.2.0.tgz#5dbeecad42f5d88b482334902ce1cba6d9798d29"
-  dependencies:
-    throat "^4.0.0"
 
 jest-changed-files@^22.4.3:
   version "22.4.3"
@@ -2173,39 +2105,11 @@ jest-changed-files@^22.4.3:
   dependencies:
     throat "^4.0.0"
 
-jest-cli@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-21.2.1.tgz#9c528b6629d651911138d228bdb033c157ec8c00"
+jest-changed-files@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-23.4.2.tgz#1eed688370cd5eebafe4ae93d34bb3b64968fe83"
   dependencies:
-    ansi-escapes "^3.0.0"
-    chalk "^2.0.1"
-    glob "^7.1.2"
-    graceful-fs "^4.1.11"
-    is-ci "^1.0.10"
-    istanbul-api "^1.1.1"
-    istanbul-lib-coverage "^1.0.1"
-    istanbul-lib-instrument "^1.4.2"
-    istanbul-lib-source-maps "^1.1.0"
-    jest-changed-files "^21.2.0"
-    jest-config "^21.2.1"
-    jest-environment-jsdom "^21.2.1"
-    jest-haste-map "^21.2.0"
-    jest-message-util "^21.2.1"
-    jest-regex-util "^21.2.0"
-    jest-resolve-dependencies "^21.2.0"
-    jest-runner "^21.2.1"
-    jest-runtime "^21.2.1"
-    jest-snapshot "^21.2.1"
-    jest-util "^21.2.1"
-    micromatch "^2.3.11"
-    node-notifier "^5.0.2"
-    pify "^3.0.0"
-    slash "^1.0.0"
-    string-length "^2.0.0"
-    strip-ansi "^4.0.0"
-    which "^1.2.12"
-    worker-farm "^1.3.1"
-    yargs "^9.0.0"
+    throat "^4.0.0"
 
 jest-cli@^22.0.0:
   version "22.4.3"
@@ -2246,21 +2150,46 @@ jest-cli@^22.0.0:
     which "^1.2.12"
     yargs "^10.0.3"
 
-jest-config@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-21.2.1.tgz#c7586c79ead0bcc1f38c401e55f964f13bf2a480"
+jest-cli@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-23.4.2.tgz#49d56bcfe6cf01871bfcc4a0494e08edaf2b61d0"
   dependencies:
+    ansi-escapes "^3.0.0"
     chalk "^2.0.1"
-    glob "^7.1.1"
-    jest-environment-jsdom "^21.2.1"
-    jest-environment-node "^21.2.1"
-    jest-get-type "^21.2.0"
-    jest-jasmine2 "^21.2.1"
-    jest-regex-util "^21.2.0"
-    jest-resolve "^21.2.0"
-    jest-util "^21.2.1"
-    jest-validate "^21.2.1"
-    pretty-format "^21.2.1"
+    exit "^0.1.2"
+    glob "^7.1.2"
+    graceful-fs "^4.1.11"
+    import-local "^1.0.0"
+    is-ci "^1.0.10"
+    istanbul-api "^1.3.1"
+    istanbul-lib-coverage "^1.2.0"
+    istanbul-lib-instrument "^1.10.1"
+    istanbul-lib-source-maps "^1.2.4"
+    jest-changed-files "^23.4.2"
+    jest-config "^23.4.2"
+    jest-environment-jsdom "^23.4.0"
+    jest-get-type "^22.1.0"
+    jest-haste-map "^23.4.1"
+    jest-message-util "^23.4.0"
+    jest-regex-util "^23.3.0"
+    jest-resolve-dependencies "^23.4.2"
+    jest-runner "^23.4.2"
+    jest-runtime "^23.4.2"
+    jest-snapshot "^23.4.2"
+    jest-util "^23.4.0"
+    jest-validate "^23.4.0"
+    jest-watcher "^23.4.0"
+    jest-worker "^23.2.0"
+    micromatch "^2.3.11"
+    node-notifier "^5.2.1"
+    prompts "^0.1.9"
+    realpath-native "^1.0.0"
+    rimraf "^2.5.4"
+    slash "^1.0.0"
+    string-length "^2.0.0"
+    strip-ansi "^4.0.0"
+    which "^1.2.12"
+    yargs "^11.0.0"
 
 jest-config@^22.4.3:
   version "22.4.3"
@@ -2278,14 +2207,23 @@ jest-config@^22.4.3:
     jest-validate "^22.4.3"
     pretty-format "^22.4.3"
 
-jest-diff@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-21.2.1.tgz#46cccb6cab2d02ce98bc314011764bb95b065b4f"
+jest-config@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-23.4.2.tgz#62a105e14b8266458f2bf4d32403b2c44418fa77"
   dependencies:
+    babel-core "^6.0.0"
+    babel-jest "^23.4.2"
     chalk "^2.0.1"
-    diff "^3.2.0"
-    jest-get-type "^21.2.0"
-    pretty-format "^21.2.1"
+    glob "^7.1.1"
+    jest-environment-jsdom "^23.4.0"
+    jest-environment-node "^23.4.0"
+    jest-get-type "^22.1.0"
+    jest-jasmine2 "^23.4.2"
+    jest-regex-util "^23.3.0"
+    jest-resolve "^23.4.1"
+    jest-util "^23.4.0"
+    jest-validate "^23.4.0"
+    pretty-format "^23.2.0"
 
 jest-diff@^22.4.3:
   version "22.4.3"
@@ -2296,9 +2234,14 @@ jest-diff@^22.4.3:
     jest-get-type "^22.4.3"
     pretty-format "^22.4.3"
 
-jest-docblock@^21.2.0:
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
+jest-diff@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-23.2.0.tgz#9f2cf4b51e12c791550200abc16b47130af1062a"
+  dependencies:
+    chalk "^2.0.1"
+    diff "^3.2.0"
+    jest-get-type "^22.1.0"
+    pretty-format "^23.2.0"
 
 jest-docblock@^22.4.3:
   version "22.4.3"
@@ -2306,13 +2249,18 @@ jest-docblock@^22.4.3:
   dependencies:
     detect-newline "^2.1.0"
 
-jest-environment-jsdom@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-21.2.1.tgz#38d9980c8259b2a608ec232deee6289a60d9d5b4"
+jest-docblock@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-23.2.0.tgz#f085e1f18548d99fdd69b20207e6fd55d91383a7"
   dependencies:
-    jest-mock "^21.2.0"
-    jest-util "^21.2.1"
-    jsdom "^9.12.0"
+    detect-newline "^2.1.0"
+
+jest-each@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-23.4.0.tgz#2fa9edd89daa1a4edc9ff9bf6062a36b71345143"
+  dependencies:
+    chalk "^2.0.1"
+    pretty-format "^23.2.0"
 
 jest-environment-jsdom@^22.4.3:
   version "22.4.3"
@@ -2322,12 +2270,13 @@ jest-environment-jsdom@^22.4.3:
     jest-util "^22.4.3"
     jsdom "^11.5.1"
 
-jest-environment-node@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-21.2.1.tgz#98c67df5663c7fbe20f6e792ac2272c740d3b8c8"
+jest-environment-jsdom@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-23.4.0.tgz#056a7952b3fea513ac62a140a2c368c79d9e6023"
   dependencies:
-    jest-mock "^21.2.0"
-    jest-util "^21.2.1"
+    jest-mock "^23.2.0"
+    jest-util "^23.4.0"
+    jsdom "^11.5.1"
 
 jest-environment-node@^22.4.3:
   version "22.4.3"
@@ -2336,24 +2285,16 @@ jest-environment-node@^22.4.3:
     jest-mock "^22.4.3"
     jest-util "^22.4.3"
 
-jest-get-type@^21.2.0:
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-21.2.0.tgz#f6376ab9db4b60d81e39f30749c6c466f40d4a23"
+jest-environment-node@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-23.4.0.tgz#57e80ed0841dea303167cce8cd79521debafde10"
+  dependencies:
+    jest-mock "^23.2.0"
+    jest-util "^23.4.0"
 
-jest-get-type@^22.4.3:
+jest-get-type@^22.1.0, jest-get-type@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.4.3.tgz#e3a8504d8479342dd4420236b322869f18900ce4"
-
-jest-haste-map@^21.2.0:
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-21.2.0.tgz#1363f0a8bb4338f24f001806571eff7a4b2ff3d8"
-  dependencies:
-    fb-watchman "^2.0.0"
-    graceful-fs "^4.1.11"
-    jest-docblock "^21.2.0"
-    micromatch "^2.3.11"
-    sane "^2.0.0"
-    worker-farm "^1.3.1"
 
 jest-haste-map@^22.4.3:
   version "22.4.3"
@@ -2367,18 +2308,17 @@ jest-haste-map@^22.4.3:
     micromatch "^2.3.11"
     sane "^2.0.0"
 
-jest-jasmine2@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-21.2.1.tgz#9cc6fc108accfa97efebce10c4308548a4ea7592"
+jest-haste-map@^23.4.1:
+  version "23.4.1"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-23.4.1.tgz#43a174ba7ac079ae1dd74eaf5a5fe78989474dd2"
   dependencies:
-    chalk "^2.0.1"
-    expect "^21.2.1"
+    fb-watchman "^2.0.0"
     graceful-fs "^4.1.11"
-    jest-diff "^21.2.1"
-    jest-matcher-utils "^21.2.1"
-    jest-message-util "^21.2.1"
-    jest-snapshot "^21.2.1"
-    p-cancelable "^0.3.0"
+    jest-docblock "^23.2.0"
+    jest-serializer "^23.0.1"
+    jest-worker "^23.2.0"
+    micromatch "^2.3.11"
+    sane "^2.0.0"
 
 jest-jasmine2@^22.4.3:
   version "22.4.3"
@@ -2396,19 +2336,34 @@ jest-jasmine2@^22.4.3:
     jest-util "^22.4.3"
     source-map-support "^0.5.0"
 
+jest-jasmine2@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-23.4.2.tgz#2fbf52f93e43ed4c5e7326a90bb1d785be4321ac"
+  dependencies:
+    babel-traverse "^6.0.0"
+    chalk "^2.0.1"
+    co "^4.6.0"
+    expect "^23.4.0"
+    is-generator-fn "^1.0.0"
+    jest-diff "^23.2.0"
+    jest-each "^23.4.0"
+    jest-matcher-utils "^23.2.0"
+    jest-message-util "^23.4.0"
+    jest-snapshot "^23.4.2"
+    jest-util "^23.4.0"
+    pretty-format "^23.2.0"
+
 jest-leak-detector@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-22.4.3.tgz#2b7b263103afae8c52b6b91241a2de40117e5b35"
   dependencies:
     pretty-format "^22.4.3"
 
-jest-matcher-utils@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-21.2.1.tgz#72c826eaba41a093ac2b4565f865eb8475de0f64"
+jest-leak-detector@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-23.2.0.tgz#c289d961dc638f14357d4ef96e0431ecc1aa377d"
   dependencies:
-    chalk "^2.0.1"
-    jest-get-type "^21.2.0"
-    pretty-format "^21.2.1"
+    pretty-format "^23.2.0"
 
 jest-matcher-utils@^22.4.3:
   version "22.4.3"
@@ -2418,13 +2373,13 @@ jest-matcher-utils@^22.4.3:
     jest-get-type "^22.4.3"
     pretty-format "^22.4.3"
 
-jest-message-util@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-21.2.1.tgz#bfe5d4692c84c827d1dcf41823795558f0a1acbe"
+jest-matcher-utils@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-23.2.0.tgz#4d4981f23213e939e3cedf23dc34c747b5ae1913"
   dependencies:
     chalk "^2.0.1"
-    micromatch "^2.3.11"
-    slash "^1.0.0"
+    jest-get-type "^22.1.0"
+    pretty-format "^23.2.0"
 
 jest-message-util@^22.4.3:
   version "22.4.3"
@@ -2436,27 +2391,31 @@ jest-message-util@^22.4.3:
     slash "^1.0.0"
     stack-utils "^1.0.1"
 
-jest-mock@^21.2.0:
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-21.2.0.tgz#7eb0770e7317968165f61ea2a7281131534b3c0f"
+jest-message-util@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-23.4.0.tgz#17610c50942349508d01a3d1e0bda2c079086a9f"
+  dependencies:
+    "@babel/code-frame" "^7.0.0-beta.35"
+    chalk "^2.0.1"
+    micromatch "^2.3.11"
+    slash "^1.0.0"
+    stack-utils "^1.0.1"
 
 jest-mock@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-22.4.3.tgz#f63ba2f07a1511772cdc7979733397df770aabc7"
 
-jest-regex-util@^21.2.0:
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-21.2.0.tgz#1b1e33e63143babc3e0f2e6c9b5ba1eb34b2d530"
+jest-mock@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-23.2.0.tgz#ad1c60f29e8719d47c26e1138098b6d18b261134"
 
 jest-regex-util@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-22.4.3.tgz#a826eb191cdf22502198c5401a1fc04de9cef5af"
 
-jest-resolve-dependencies@^21.2.0:
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-21.2.0.tgz#9e231e371e1a736a1ad4e4b9a843bc72bfe03d09"
-  dependencies:
-    jest-regex-util "^21.2.0"
+jest-regex-util@^23.3.0:
+  version "23.3.0"
+  resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-23.3.0.tgz#5f86729547c2785c4002ceaa8f849fe8ca471bc5"
 
 jest-resolve-dependencies@^22.4.3:
   version "22.4.3"
@@ -2464,13 +2423,12 @@ jest-resolve-dependencies@^22.4.3:
   dependencies:
     jest-regex-util "^22.4.3"
 
-jest-resolve@^21.2.0:
-  version "21.2.0"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-21.2.0.tgz#068913ad2ba6a20218e5fd32471f3874005de3a6"
+jest-resolve-dependencies@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-23.4.2.tgz#0675ba876a5b819deffc449ad72e9985c2592048"
   dependencies:
-    browser-resolve "^1.11.2"
-    chalk "^2.0.1"
-    is-builtin-module "^1.0.0"
+    jest-regex-util "^23.3.0"
+    jest-snapshot "^23.4.2"
 
 jest-resolve@^22.4.3:
   version "22.4.3"
@@ -2479,20 +2437,13 @@ jest-resolve@^22.4.3:
     browser-resolve "^1.11.2"
     chalk "^2.0.1"
 
-jest-runner@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-21.2.1.tgz#194732e3e518bfb3d7cbfc0fd5871246c7e1a467"
+jest-resolve@^23.4.1:
+  version "23.4.1"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-23.4.1.tgz#7f3c17104732a2c0c940a01256025ed745814982"
   dependencies:
-    jest-config "^21.2.1"
-    jest-docblock "^21.2.0"
-    jest-haste-map "^21.2.0"
-    jest-jasmine2 "^21.2.1"
-    jest-message-util "^21.2.1"
-    jest-runtime "^21.2.1"
-    jest-util "^21.2.1"
-    pify "^3.0.0"
-    throat "^4.0.0"
-    worker-farm "^1.3.1"
+    browser-resolve "^1.11.3"
+    chalk "^2.0.1"
+    realpath-native "^1.0.0"
 
 jest-runner@^22.4.3:
   version "22.4.3"
@@ -2510,27 +2461,23 @@ jest-runner@^22.4.3:
     jest-worker "^22.4.3"
     throat "^4.0.0"
 
-jest-runtime@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-21.2.1.tgz#99dce15309c670442eee2ebe1ff53a3cbdbbb73e"
+jest-runner@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-23.4.2.tgz#579a88524ac52c846075b0129a21c7b483e75a7e"
   dependencies:
-    babel-core "^6.0.0"
-    babel-jest "^21.2.0"
-    babel-plugin-istanbul "^4.0.0"
-    chalk "^2.0.1"
-    convert-source-map "^1.4.0"
+    exit "^0.1.2"
     graceful-fs "^4.1.11"
-    jest-config "^21.2.1"
-    jest-haste-map "^21.2.0"
-    jest-regex-util "^21.2.0"
-    jest-resolve "^21.2.0"
-    jest-util "^21.2.1"
-    json-stable-stringify "^1.0.1"
-    micromatch "^2.3.11"
-    slash "^1.0.0"
-    strip-bom "3.0.0"
-    write-file-atomic "^2.1.0"
-    yargs "^9.0.0"
+    jest-config "^23.4.2"
+    jest-docblock "^23.2.0"
+    jest-haste-map "^23.4.1"
+    jest-jasmine2 "^23.4.2"
+    jest-leak-detector "^23.2.0"
+    jest-message-util "^23.4.0"
+    jest-runtime "^23.4.2"
+    jest-util "^23.4.0"
+    jest-worker "^23.2.0"
+    source-map-support "^0.5.6"
+    throat "^4.0.0"
 
 jest-runtime@^22.4.3:
   version "22.4.3"
@@ -2557,20 +2504,39 @@ jest-runtime@^22.4.3:
     write-file-atomic "^2.1.0"
     yargs "^10.0.3"
 
+jest-runtime@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-23.4.2.tgz#00c3bb8385253d401a394a27d1112d3615e5a65c"
+  dependencies:
+    babel-core "^6.0.0"
+    babel-plugin-istanbul "^4.1.6"
+    chalk "^2.0.1"
+    convert-source-map "^1.4.0"
+    exit "^0.1.2"
+    fast-json-stable-stringify "^2.0.0"
+    graceful-fs "^4.1.11"
+    jest-config "^23.4.2"
+    jest-haste-map "^23.4.1"
+    jest-message-util "^23.4.0"
+    jest-regex-util "^23.3.0"
+    jest-resolve "^23.4.1"
+    jest-snapshot "^23.4.2"
+    jest-util "^23.4.0"
+    jest-validate "^23.4.0"
+    micromatch "^2.3.11"
+    realpath-native "^1.0.0"
+    slash "^1.0.0"
+    strip-bom "3.0.0"
+    write-file-atomic "^2.1.0"
+    yargs "^11.0.0"
+
 jest-serializer@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-22.4.3.tgz#a679b81a7f111e4766235f4f0c46d230ee0f7436"
 
-jest-snapshot@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-21.2.1.tgz#29e49f16202416e47343e757e5eff948c07fd7b0"
-  dependencies:
-    chalk "^2.0.1"
-    jest-diff "^21.2.1"
-    jest-matcher-utils "^21.2.1"
-    mkdirp "^0.5.1"
-    natural-compare "^1.4.0"
-    pretty-format "^21.2.1"
+jest-serializer@^23.0.1:
+  version "23.0.1"
+  resolved "https://registry.yarnpkg.com/jest-serializer/-/jest-serializer-23.0.1.tgz#a3776aeb311e90fe83fab9e533e85102bd164165"
 
 jest-snapshot@^22.4.3:
   version "22.4.3"
@@ -2583,17 +2549,20 @@ jest-snapshot@^22.4.3:
     natural-compare "^1.4.0"
     pretty-format "^22.4.3"
 
-jest-util@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-21.2.1.tgz#a274b2f726b0897494d694a6c3d6a61ab819bb78"
+jest-snapshot@^23.4.2:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-23.4.2.tgz#8fa6130feb5a527dac73e5fa80d86f29f7c42ab6"
   dependencies:
-    callsites "^2.0.0"
+    babel-types "^6.0.0"
     chalk "^2.0.1"
-    graceful-fs "^4.1.11"
-    jest-message-util "^21.2.1"
-    jest-mock "^21.2.0"
-    jest-validate "^21.2.1"
+    jest-diff "^23.2.0"
+    jest-matcher-utils "^23.2.0"
+    jest-message-util "^23.4.0"
+    jest-resolve "^23.4.1"
     mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    pretty-format "^23.2.0"
+    semver "^5.5.0"
 
 jest-util@^22.4.3:
   version "22.4.3"
@@ -2607,14 +2576,18 @@ jest-util@^22.4.3:
     mkdirp "^0.5.1"
     source-map "^0.6.0"
 
-jest-validate@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-21.2.1.tgz#cc0cbca653cd54937ba4f2a111796774530dd3c7"
+jest-util@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-23.4.0.tgz#4d063cb927baf0a23831ff61bec2cbbf49793561"
   dependencies:
+    callsites "^2.0.0"
     chalk "^2.0.1"
-    jest-get-type "^21.2.0"
-    leven "^2.1.0"
-    pretty-format "^21.2.1"
+    graceful-fs "^4.1.11"
+    is-ci "^1.0.10"
+    jest-message-util "^23.4.0"
+    mkdirp "^0.5.1"
+    slash "^1.0.0"
+    source-map "^0.6.0"
 
 jest-validate@^22.4.3:
   version "22.4.3"
@@ -2626,17 +2599,41 @@ jest-validate@^22.4.3:
     leven "^2.1.0"
     pretty-format "^22.4.3"
 
+jest-validate@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-23.4.0.tgz#d96eede01ef03ac909c009e9c8e455197d48c201"
+  dependencies:
+    chalk "^2.0.1"
+    jest-get-type "^22.1.0"
+    leven "^2.1.0"
+    pretty-format "^23.2.0"
+
+jest-watcher@^23.4.0:
+  version "23.4.0"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-23.4.0.tgz#d2e28ce74f8dad6c6afc922b92cabef6ed05c91c"
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.1"
+    string-length "^2.0.0"
+
 jest-worker@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-22.4.3.tgz#5c421417cba1c0abf64bf56bd5fb7968d79dd40b"
   dependencies:
     merge-stream "^1.0.1"
 
-jest@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-21.2.1.tgz#c964e0b47383768a1438e3ccf3c3d470327604e1"
+jest-worker@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-23.2.0.tgz#faf706a8da36fae60eb26957257fa7b5d8ea02b9"
   dependencies:
-    jest-cli "^21.2.1"
+    merge-stream "^1.0.1"
+
+jest@^23.0.0:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-23.4.2.tgz#1fae3ed832192143070ae85156b25cea891a1260"
+  dependencies:
+    import-local "^1.0.0"
+    jest-cli "^23.4.2"
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
@@ -2683,30 +2680,6 @@ jsdom@^11.5.1:
     whatwg-url "^6.4.0"
     ws "^4.0.0"
     xml-name-validator "^3.0.0"
-
-jsdom@^9.12.0:
-  version "9.12.0"
-  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-9.12.0.tgz#e8c546fffcb06c00d4833ca84410fed7f8a097d4"
-  dependencies:
-    abab "^1.0.3"
-    acorn "^4.0.4"
-    acorn-globals "^3.1.0"
-    array-equal "^1.0.0"
-    content-type-parser "^1.0.1"
-    cssom ">= 0.3.2 < 0.4.0"
-    cssstyle ">= 0.2.37 < 0.3.0"
-    escodegen "^1.6.1"
-    html-encoding-sniffer "^1.0.1"
-    nwmatcher ">= 1.3.9 < 2.0.0"
-    parse5 "^1.5.1"
-    request "^2.79.0"
-    sax "^1.2.1"
-    symbol-tree "^3.2.1"
-    tough-cookie "^2.3.2"
-    webidl-conversions "^4.0.0"
-    whatwg-encoding "^1.0.1"
-    whatwg-url "^4.3.0"
-    xml-name-validator "^2.0.1"
 
 jsesc@^1.3.0:
   version "1.3.0"
@@ -2771,6 +2744,10 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
 
+kleur@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/kleur/-/kleur-2.0.1.tgz#7cc64b0d188d0dcbc98bdcdfdda2cc10619ddce8"
+
 lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
@@ -2805,15 +2782,6 @@ load-json-file@^1.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
-
-load-json-file@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"
-  dependencies:
-    graceful-fs "^4.1.2"
-    parse-json "^2.2.0"
-    pify "^2.0.0"
-    strip-bom "^3.0.0"
 
 locate-path@^2.0.0:
   version "2.0.0"
@@ -2993,15 +2961,6 @@ node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
 
-node-notifier@^5.0.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.1.2.tgz#2fa9e12605fa10009d44549d6fcd8a63dde0e4ff"
-  dependencies:
-    growly "^1.3.0"
-    semver "^5.3.0"
-    shellwords "^0.1.0"
-    which "^1.2.12"
-
 node-notifier@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.2.1.tgz#fa313dd08f5517db0e2502e5758d664ac69f9dea"
@@ -3066,10 +3025,6 @@ npmlog@^4.0.2:
 number-is-nan@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
-
-"nwmatcher@>= 1.3.9 < 2.0.0":
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/nwmatcher/-/nwmatcher-1.4.3.tgz#64348e3b3d80f035b40ac11563d278f8b72db89c"
 
 nwmatcher@^1.4.3:
   version "1.4.4"
@@ -3176,10 +3131,6 @@ output-file-sync@^1.1.2:
     mkdirp "^0.5.1"
     object-assign "^4.1.0"
 
-p-cancelable@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-0.3.0.tgz#b9e123800bcebb7ac13a479be195b507b98d30fa"
-
 p-finally@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
@@ -3212,10 +3163,6 @@ parse-json@^2.2.0:
 parse5@4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-4.0.0.tgz#6d78656e3da8d78b4ec0b906f7c08ef1dfe3f608"
-
-parse5@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
 
 pascalcase@^0.1.1:
   version "0.1.1"
@@ -3251,12 +3198,6 @@ path-type@^1.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-path-type@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
-  dependencies:
-    pify "^2.0.0"
-
 performance-now@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-0.2.0.tgz#33ef30c5c77d4ea21c5a53869d91b56d8f2555e5"
@@ -3268,10 +3209,6 @@ performance-now@^2.1.0:
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
-
-pify@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
 
 pinkie-promise@^2.0.0:
   version "2.0.1"
@@ -3305,16 +3242,16 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-pretty-format@^21.2.1:
-  version "21.2.1"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-21.2.1.tgz#ae5407f3cf21066cd011aa1ba5fce7b6a2eddb36"
+pretty-format@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-22.4.3.tgz#f873d780839a9c02e9664c8a082e9ee79eaac16f"
   dependencies:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
-pretty-format@^22.4.3:
-  version "22.4.3"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-22.4.3.tgz#f873d780839a9c02e9664c8a082e9ee79eaac16f"
+pretty-format@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-23.2.0.tgz#3b0aaa63c018a53583373c1cb3a5d96cc5e83017"
   dependencies:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
@@ -3331,9 +3268,12 @@ process-nextick-args@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.0.tgz#a37d732f4271b4ab1ad070d35508e8290788ffaa"
 
-prr@~0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/prr/-/prr-0.0.0.tgz#1a84b85908325501411853d0081ee3fa86e2926a"
+prompts@^0.1.9:
+  version "0.1.13"
+  resolved "https://registry.yarnpkg.com/prompts/-/prompts-0.1.13.tgz#7fad7ee1c6cafe49834ca0b2a6a471262de57620"
+  dependencies:
+    kleur "^2.0.1"
+    sisteransi "^0.1.1"
 
 pseudomap@^1.0.2:
   version "1.0.2"
@@ -3378,13 +3318,6 @@ read-pkg-up@^1.0.1:
     find-up "^1.0.0"
     read-pkg "^1.0.0"
 
-read-pkg-up@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"
-  dependencies:
-    find-up "^2.0.0"
-    read-pkg "^2.0.0"
-
 read-pkg@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
@@ -3392,14 +3325,6 @@ read-pkg@^1.0.0:
     load-json-file "^1.0.0"
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
-
-read-pkg@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-2.0.0.tgz#8ef1c0623c6a6db0dc6713c4bfac46332b2368f8"
-  dependencies:
-    load-json-file "^2.0.0"
-    normalize-package-data "^2.3.2"
-    path-type "^2.0.0"
 
 readable-stream@^2.0.1:
   version "2.3.6"
@@ -3550,33 +3475,6 @@ request@2.81.0:
     tunnel-agent "^0.6.0"
     uuid "^3.0.0"
 
-request@^2.79.0:
-  version "2.83.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.83.0.tgz#ca0b65da02ed62935887808e6f510381034e3356"
-  dependencies:
-    aws-sign2 "~0.7.0"
-    aws4 "^1.6.0"
-    caseless "~0.12.0"
-    combined-stream "~1.0.5"
-    extend "~3.0.1"
-    forever-agent "~0.6.1"
-    form-data "~2.3.1"
-    har-validator "~5.0.3"
-    hawk "~6.0.2"
-    http-signature "~1.2.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.17"
-    oauth-sign "~0.8.2"
-    performance-now "^2.1.0"
-    qs "~6.5.1"
-    safe-buffer "^5.1.1"
-    stringstream "~0.0.5"
-    tough-cookie "~2.3.3"
-    tunnel-agent "^0.6.0"
-    uuid "^3.1.0"
-
 request@^2.83.0:
   version "2.85.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.85.0.tgz#5a03615a47c61420b3eb99b7dba204f83603e1fa"
@@ -3676,7 +3574,7 @@ sane@^2.0.0:
   optionalDependencies:
     fsevents "^1.1.1"
 
-sax@^1.2.1, sax@^1.2.4:
+sax@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
 
@@ -3684,7 +3582,7 @@ sax@^1.2.1, sax@^1.2.4:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
-semver@^5.4.1:
+semver@^5.4.1, semver@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
 
@@ -3724,13 +3622,17 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-shellwords@^0.1.0, shellwords@^0.1.1:
+shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+sisteransi@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-0.1.1.tgz#5431447d5f7d1675aac667ccd0b865a4994cb3ce"
 
 slash@^1.0.0:
   version "1.0.0"
@@ -3791,7 +3693,7 @@ source-map-support@^0.4.15:
   dependencies:
     source-map "^0.5.6"
 
-source-map-support@^0.5.0:
+source-map-support@^0.5.0, source-map-support@^0.5.6:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.6.tgz#4435cee46b1aab62b8e8610ce60f788091c51c13"
   dependencies:
@@ -3808,7 +3710,7 @@ source-map@^0.4.4:
   dependencies:
     amdefine ">=0.0.4"
 
-source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1, source-map@~0.5.6:
+source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
@@ -3919,7 +3821,7 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
-strip-bom@3.0.0, strip-bom@^3.0.0:
+strip-bom@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
 
@@ -3963,7 +3865,7 @@ symbol-observable@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
 
-symbol-tree@^3.2.1, symbol-tree@^3.2.2:
+symbol-tree@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.2.tgz#ae27db38f660a7ae2e1c3b7d1bc290819b8519e6"
 
@@ -4048,7 +3950,7 @@ tough-cookie@>=2.3.3, tough-cookie@^2.3.3:
   dependencies:
     punycode "^1.4.1"
 
-tough-cookie@^2.3.2, tough-cookie@~2.3.0, tough-cookie@~2.3.3:
+tough-cookie@~2.3.0, tough-cookie@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.3.tgz#0b618a5565b6dea90bf3425d04d55edc475a7561"
   dependencies:
@@ -4059,10 +3961,6 @@ tr46@^1.0.1:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
   dependencies:
     punycode "^2.1.0"
-
-tr46@~0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
 
 trim-right@^1.0.1:
   version "1.0.1"
@@ -4186,11 +4084,7 @@ watch@~0.18.0:
     exec-sh "^0.2.0"
     minimist "^1.2.0"
 
-webidl-conversions@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
-
-webidl-conversions@^4.0.0, webidl-conversions@^4.0.2:
+webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
 
@@ -4209,13 +4103,6 @@ whatwg-encoding@^1.0.3:
 whatwg-mimetype@^2.0.0, whatwg-mimetype@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-2.1.0.tgz#f0f21d76cbba72362eb609dbed2a30cd17fcc7d4"
-
-whatwg-url@^4.3.0:
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-4.8.0.tgz#d2981aa9148c1e00a41c5a6131166ab4683bbcc0"
-  dependencies:
-    tr46 "~0.0.3"
-    webidl-conversions "^3.0.0"
 
 whatwg-url@^6.4.0:
   version "6.4.1"
@@ -4257,13 +4144,6 @@ wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
 
-worker-farm@^1.3.1:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.5.0.tgz#adfdf0cd40581465ed0a1f648f9735722afd5c8d"
-  dependencies:
-    errno "^0.1.4"
-    xtend "^4.0.1"
-
 wrap-ansi@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
@@ -4290,17 +4170,9 @@ ws@^4.0.0:
     async-limiter "~1.0.0"
     safe-buffer "~5.1.0"
 
-xml-name-validator@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
-
 xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
-
-xtend@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 
 y18n@^3.2.1:
   version "3.2.1"
@@ -4310,15 +4182,15 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
-yargs-parser@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-7.0.0.tgz#8d0ac42f16ea55debd332caf4c4038b3e3f5dfd9"
-  dependencies:
-    camelcase "^4.1.0"
-
 yargs-parser@^8.1.0:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-8.1.0.tgz#f1376a33b6629a5d063782944da732631e966950"
+  dependencies:
+    camelcase "^4.1.0"
+
+yargs-parser@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
   dependencies:
     camelcase "^4.1.0"
 
@@ -4339,23 +4211,22 @@ yargs@^10.0.3:
     y18n "^3.2.1"
     yargs-parser "^8.1.0"
 
-yargs@^9.0.0:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-9.0.1.tgz#52acc23feecac34042078ee78c0c007f5085db4c"
+yargs@^11.0.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
   dependencies:
-    camelcase "^4.1.0"
-    cliui "^3.2.0"
+    cliui "^4.0.0"
     decamelize "^1.1.1"
+    find-up "^2.1.0"
     get-caller-file "^1.0.1"
     os-locale "^2.0.0"
-    read-pkg-up "^2.0.0"
     require-directory "^2.1.1"
     require-main-filename "^1.0.1"
     set-blocking "^2.0.0"
     string-width "^2.0.0"
     which-module "^2.0.0"
     y18n "^3.2.1"
-    yargs-parser "^7.0.0"
+    yargs-parser "^9.0.2"
 
 yargs@~3.10.0:
   version "3.10.0"


### PR DESCRIPTION
<p>This Pull Request updates dependency <a href="https://renovatebot.com/gh/facebook/jest">jest</a> from <code>^21.2.1</code> to <code>^23.0.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v2342httpsgithubcomfacebookjestblobmasterchangelogmd82032342"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2342"><code>v23.4.2</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v23.4.1…v23.4.2">Compare Source</a></p>
<h5 id="performance">Performance</h5>
<ul>
<li><code>[jest-changed-files]</code> limit git and hg commands to specified roots (<a href="https://renovatebot.com/gh/facebook/jest/pull/6732">#&#8203;6732</a>)</li>
</ul>
<h5 id="fixes">Fixes</h5>
<ul>
<li><code>[jest-circus]</code> Fix retryTimes so errors are reset before re-running (<a href="https://renovatebot.com/gh/facebook/jest/pull/6762">#&#8203;6762</a>)</li>
<li><code>[docs]</code> Update <code>expect.objectContaining()</code> description (<a href="https://renovatebot.com/gh/facebook/jest/pull/6754">#&#8203;6754</a>)</li>
<li><code>[babel-jest]</code> Make <code>getCacheKey()</code> take into account <code>createTransformer</code> options (<a href="https://renovatebot.com/gh/facebook/jest/pull/6699">#&#8203;6699</a>)</li>
<li><code>[jest-jasmine2]</code> Use prettier through <code>require</code> instead of <code>localRequire</code>. Fixes <code>matchInlineSnapshot</code> where prettier dependencies like <code>path</code> and <code>fs</code> are mocked with <code>jest.mock</code>. (<a href="https://renovatebot.com/gh/facebook/jest/pull/6776">#&#8203;6776</a>)</li>
<li><code>[docs]</code> Fix contributors link (<a href="https://renovatebot.com/gh/facebook/jest/pull/6711">#&#8203;6711</a>)</li>
<li><code>[website]</code> Fix website versions page to link to correct language (<a href="https://renovatebot.com/gh/facebook/jest/pull/6734">#&#8203;6734</a>)</li>
</ul>
<hr />
<h3 id="v2341httpsgithubcomfacebookjestblobmasterchangelogmd82032341"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2341"><code>v23.4.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v23.4.0…v23.4.1">Compare Source</a></p>
<h5 id="features">Features</h5>
<ul>
<li><code>[jest-cli]</code> Watch plugins now have access to a broader range of global configuration options in their <code>updateConfigAndRun</code> callbacks, so they can provide a wider set of extra features (<a href="https://renovatebot.com/gh/facebook/jest/pull/6473">#&#8203;6473</a>)</li>
<li><code>[jest-snapshot]</code> <code>babel-traverse</code> is now passed to <code>jest-snapshot</code> explicitly to avoid unnecessary requires in every test</li>
</ul>
<h5 id="fixes-1">Fixes</h5>
<ul>
<li><code>[jest-haste-map]</code> Optimize watchman crawler by using <code>glob</code> on initial query (<a href="https://renovatebot.com/gh/facebook/jest/pull/6689">#&#8203;6689</a>)</li>
</ul>
<hr />
<h3 id="v2340httpsgithubcomfacebookjestblobmasterchangelogmd82032340"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2340"><code>v23.4.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v23.3.0…v23.4.0">Compare Source</a></p>
<h5 id="features-1">Features</h5>
<ul>
<li><code>[jest-haste-map]</code> Add <code>computeDependencies</code> flag to avoid opening files if not needed (<a href="https://renovatebot.com/gh/facebook/jest/pull/6667">#&#8203;6667</a>)</li>
<li><code>[jest-runtime]</code> Support <code>require.resolve.paths</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6471">#&#8203;6471</a>)</li>
<li><code>[jest-runtime]</code> Support <code>paths</code> option for <code>require.resolve</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6471">#&#8203;6471</a>)</li>
</ul>
<h5 id="fixes-2">Fixes</h5>
<ul>
<li><code>[jest-runner]</code> Force parallel runs for watch mode, to avoid TTY freeze (<a href="https://renovatebot.com/gh/facebook/jest/pull/6647">#&#8203;6647</a>)</li>
<li><code>[jest-cli]</code> properly reprint resolver errors in watch mode (<a href="https://renovatebot.com/gh/facebook/jest/pull/6407">#&#8203;6407</a>)</li>
<li><code>[jest-cli]</code> Write configuration to stdout when the option was explicitly passed to Jest (<a href="https://renovatebot.com/gh/facebook/jest/pull/6447">#&#8203;6447</a>)</li>
<li><code>[jest-cli]</code> Fix regression on non-matching suites (<a href="https://renovatebot.com/gh/facebook/jest/pull/6657">6657</a>)</li>
<li><code>[jest-runtime]</code> Roll back <code>micromatch</code> version to prevent regression when matching files (<a href="https://renovatebot.com/gh/facebook/jest/pull/6661">#&#8203;6661</a>)</li>
</ul>
<hr />
<h3 id="v2330httpsgithubcomfacebookjestblobmasterchangelogmd82032330"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2330"><code>v23.3.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v23.2.0…v23.3.0">Compare Source</a></p>
<h5 id="features-2">Features</h5>
<ul>
<li><code>[jest-cli]</code> Allow watch plugin to be configured (<a href="https://renovatebot.com/gh/facebook/jest/pull/6603">#&#8203;6603</a>)</li>
<li><code>[jest-snapshot]</code> Introduce <code>toMatchInlineSnapshot</code> and <code>toThrowErrorMatchingInlineSnapshot</code> matchers (<a href="https://renovatebot.com/gh/facebook/jest/pull/6380">#&#8203;6380</a>)</li>
</ul>
<h5 id="fixes-3">Fixes</h5>
<ul>
<li><code>[jest-regex-util]</code> Improve handling already escaped path separators on Windows (<a href="https://renovatebot.com/gh/facebook/jest/pull/6523">#&#8203;6523</a>)</li>
<li><code>[jest-cli]</code> Fix <code>testNamePattern</code> value with interactive snapshots (<a href="https://renovatebot.com/gh/facebook/jest/pull/6579">#&#8203;6579</a>)</li>
<li><code>[jest-cli]</code> Fix enter to interrupt watch mode (<a href="https://renovatebot.com/gh/facebook/jest/pull/6601">#&#8203;6601</a>)</li>
</ul>
<h5 id="chore--maintenance">Chore &amp; Maintenance</h5>
<ul>
<li><code>[website]</code> Switch domain to <a href="https://jestjs.io">https://jestjs.io</a> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6549">#&#8203;6549</a>)</li>
<li><code>[tests]</code> Improve stability of <code>yarn test</code> on Windows (<a href="https://renovatebot.com/gh/facebook/jest/pull/6534">#&#8203;6534</a>)</li>
<li><code>[*]</code> Transpile object shorthand into Node 4 compatible syntax (<a href="https://renovatebot.com/gh/facebook/jest/pull/6582">#&#8203;6582</a>)</li>
<li><code>[*]</code> Update all legacy links to jestjs.io (<a href="https://renovatebot.com/gh/facebook/jest/pull/6622">#&#8203;6622</a>)</li>
<li><code>[docs]</code> Add docs for 23.1, 23.2, and 23.3 (<a href="https://renovatebot.com/gh/facebook/jest/pull/6623">#&#8203;6623</a>)</li>
<li><code>[website]</code> Only test/deploy website if relevant files are changed (<a href="https://renovatebot.com/gh/facebook/jest/pull/6626">#&#8203;6626</a>)</li>
<li><code>[docs]</code> Describe behavior of <code>resetModules</code> option when set to <code>false</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6641">#&#8203;6641</a>)</li>
</ul>
<hr />
<h3 id="v2320httpsgithubcomfacebookjestblobmasterchangelogmd82032320"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2320"><code>v23.2.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v23.1.0…v23.2.0">Compare Source</a></p>
<h5 id="features-3">Features</h5>
<ul>
<li><code>[jest-each]</code> Add support for keyPaths in test titles (<a href="https://renovatebot.com/gh/facebook/jest/pull/6457">#&#8203;6457</a>)</li>
<li><code>[jest-cli]</code> Add <code>jest --init</code> option that generates a basic configuration file with a short description for each option (<a href="https://renovatebot.com/gh/facebook/jest/pull/6442">#&#8203;6442</a>)</li>
<li><code>[jest.retryTimes]</code> Add <code>jest.retryTimes()</code> option that allows failed tests to be retried n-times when using jest-circus. (<a href="https://renovatebot.com/gh/facebook/jest/pull/6498">#&#8203;6498</a>)</li>
</ul>
<h5 id="fixes-4">Fixes</h5>
<ul>
<li><code>[jest-cli]</code> Add check to make sure one or more tests have run before notifying when using <code>--notify</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6495">#&#8203;6495</a>)</li>
<li><code>[jest-cli]</code> Pass <code>globalConfig</code> as a parameter to <code>globalSetup</code> and <code>globalTeardown</code> functions (<a href="https://renovatebot.com/gh/facebook/jest/pull/6486">#&#8203;6486</a>)</li>
<li><code>[jest-config]</code> Add missing options to the <code>defaults</code> object (<a href="https://renovatebot.com/gh/facebook/jest/pull/6428">#&#8203;6428</a>)</li>
<li><code>[expect]</code> Using symbolic property names in arrays no longer causes the <code>toEqual</code> matcher to fail (<a href="https://renovatebot.com/gh/facebook/jest/pull/6391">#&#8203;6391</a>)</li>
<li><code>[expect]</code> <code>toEqual</code> no longer tries to compare non-enumerable symbolic properties, to be consistent with non-symbolic properties. (<a href="https://renovatebot.com/gh/facebook/jest/pull/6398">#&#8203;6398</a>)</li>
<li><code>[jest-util]</code> <code>console.timeEnd</code> now properly log elapsed time in milliseconds. (<a href="https://renovatebot.com/gh/facebook/jest/pull/6456">#&#8203;6456</a>)</li>
<li><code>[jest-mock]</code> Fix <code>MockNativeMethods</code> access in react-native <code>jest.mock()</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6505">#&#8203;6505</a>)</li>
</ul>
<h5 id="chore--maintenance-1">Chore &amp; Maintenance</h5>
<ul>
<li><code>[docs]</code> Add jest-each docs for 1 dimensional arrays (<a href="https://renovatebot.com/gh/facebook/jest/pull/6444/files">#&#8203;6444</a>)</li>
</ul>
<hr />
<h3 id="v2310httpsgithubcomfacebookjestblobmasterchangelogmd82032310"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2310"><code>v23.1.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v23.0.1…v23.1.0">Compare Source</a></p>
<h5 id="features-4">Features</h5>
<ul>
<li><code>[jest-each]</code> Add pretty-format serialising to each titles (<a href="https://renovatebot.com/gh/facebook/jest/pull/6357">#&#8203;6357</a>)</li>
<li><code>[jest-cli]</code> shouldRunTestSuite watch hook now receives an object with <code>config</code>, <code>testPath</code> and <code>duration</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6350">#&#8203;6350</a>)</li>
<li><code>[jest-each]</code> Support one dimensional array of data (<a href="https://renovatebot.com/gh/facebook/jest/pull/6351">#&#8203;6351</a>)</li>
<li><code>[jest-watch]</code> create new package <code>jest-watch</code> to ease custom watch plugin development (<a href="https://renovatebot.com/gh/facebook/jest/pull/6318">#&#8203;6318</a>)</li>
<li><code>[jest-circus]</code> Make hooks in empty describe blocks error (<a href="https://renovatebot.com/gh/facebook/jest/pull/6320">#&#8203;6320</a>)</li>
<li>Add a config/CLI option <code>errorOnDeprecated</code> which makes calling deprecated APIs throw hepful error messages (<a href="https://renovatebot.com/gh/facebook/jest/pull/6339">#&#8203;6339</a>)</li>
</ul>
<h5 id="fixes-5">Fixes</h5>
<ul>
<li><code>[jest-each]</code> Fix pluralising missing arguments error (<a href="https://renovatebot.com/gh/facebook/jest/pull/6369">#&#8203;6369</a>)</li>
<li><code>[jest-each]</code> Stop test title concatenating extra args (<a href="https://renovatebot.com/gh/facebook/jest/pull/6346">#&#8203;6346</a>)</li>
<li><code>[expect]</code> toHaveBeenNthCalledWith/nthCalledWith gives wrong call messages if not matched (<a href="https://renovatebot.com/gh/facebook/jest/pull/6340">#&#8203;6340</a>)</li>
<li><code>[jest-each]</code> Make sure invalid arguments to <code>each</code> points back to the user's code (<a href="https://renovatebot.com/gh/facebook/jest/pull/6347">#&#8203;6347</a>)</li>
<li><code>[expect]</code> toMatchObject throws TypeError when a source property is null (<a href="https://renovatebot.com/gh/facebook/jest/pull/6313">#&#8203;6313</a>)</li>
<li><code>[jest-cli]</code> Normalize slashes in paths in CLI output on Windows (<a href="https://renovatebot.com/gh/facebook/jest/pull/6310">#&#8203;6310</a>)</li>
<li><code>[jest-cli]</code> Fix run beforeAll in excluded suites tests" mode. (<a href="https://renovatebot.com/gh/facebook/jest/pull/6234">#&#8203;6234</a>)</li>
<li><code>[jest-haste-map</code>] Compute SHA-1s for non-tracked files when using Node crawler (<a href="https://renovatebot.com/gh/facebook/jest/pull/6264">#&#8203;6264</a>)</li>
</ul>
<h5 id="chore--maintenance-2">Chore &amp; Maintenance</h5>
<ul>
<li><code>[docs]</code> Improve documentation of <code>mockClear</code>, <code>mockReset</code>, and <code>mockRestore</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6227/files">#&#8203;6227</a>)</li>
<li><code>[jest-circus]</code> Add dependency on jest-each (<a href="https://renovatebot.com/gh/facebook/jest/pull/#&#8203;6309">#&#8203;6309</a>)</li>
<li><code>[jest-each]</code> Refactor each to use shared implementation with core (<a href="https://renovatebot.com/gh/facebook/jest/pull/6345">#&#8203;6345</a>)</li>
<li><code>[jest-each]</code> Update jest-each docs for serialising values into titles (<a href="https://renovatebot.com/gh/facebook/jest/pull/6337">#&#8203;6337</a>)</li>
<li><code>[jest-circus]</code> Add dependency on jest-each (<a href="https://renovatebot.com/gh/facebook/jest/pull/6309">#&#8203;6309</a>)</li>
<li><code>[filenames]</code> Rename "integration-tests" to "e2e" (<a href="https://renovatebot.com/gh/facebook/jest/pull/6315">#&#8203;6315</a>)</li>
<li><code>[docs]</code> Mention the use of commit hash with <code>--changedSince</code> flag (<a href="https://renovatebot.com/gh/facebook/jest/pull/6330">#&#8203;6330</a>)</li>
</ul>
<hr />
<h3 id="v2301httpsgithubcomfacebookjestblobmasterchangelogmd82032301"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2301"><code>v23.0.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v23.0.0…v23.0.1">Compare Source</a></p>
<h5 id="chore--maintenance-3">Chore &amp; Maintenance</h5>
<ul>
<li><code>[jest-jasemine2]</code> Add dependency on jest-each (<a href="https://renovatebot.com/gh/facebook/jest/pull/6308">#&#8203;6308</a>)</li>
<li><code>[jest-each]</code> Move jest-each into core Jest (<a href="https://renovatebot.com/gh/facebook/jest/pull/6278">#&#8203;6278</a>)</li>
<li><code>[examples]</code> Update typescript example to using ts-jest (<a href="https://renovatebot.com/gh/facebook/jest/pull/6260">#&#8203;6260</a>)</li>
</ul>
<h5 id="fixes-6">Fixes</h5>
<ul>
<li><code>[pretty-format]</code> Serialize inverse asymmetric matchers correctly (<a href="https://renovatebot.com/gh/facebook/jest/pull/6272">#&#8203;6272</a>)</li>
</ul>
<hr />
<h3 id="v2300httpsgithubcomfacebookjestblobmasterchangelogmd82032300"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2300"><code>v23.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.4.4…v23.0.0">Compare Source</a></p>
<h5 id="features-5">Features</h5>
<ul>
<li><code>[expect]</code> Expose <code>getObjectSubset</code>, <code>iterableEquality</code>, and <code>subsetEquality</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6210">#&#8203;6210</a>)</li>
<li><code>[jest-snapshot]</code> Add snapshot property matchers (<a href="https://renovatebot.com/gh/facebook/jest/pull/6210">#&#8203;6210</a>)</li>
<li><code>[jest-config]</code> Support jest-preset.js files within Node modules (<a href="https://renovatebot.com/gh/facebook/jest/pull/6185">#&#8203;6185</a>)</li>
<li><code>[jest-cli]</code> Add <code>--detectOpenHandles</code> flag which enables Jest to potentially track down handles keeping it open after tests are complete. (<a href="https://renovatebot.com/gh/facebook/jest/pull/6130">#&#8203;6130</a>)</li>
<li><code>[jest-jasmine2]</code> Add data driven testing based on <code>jest-each</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6102">#&#8203;6102</a>)</li>
<li><code>[jest-matcher-utils]</code> Change "suggest to equal" message to be more advisory (<a href="https://renovatebot.com/gh/facebook/jest/issues/6103">#&#8203;6103</a>)</li>
<li><code>[jest-message-util]</code> Don't ignore messages with <code>vendor</code> anymore (<a href="https://renovatebot.com/gh/facebook/jest/pull/6117">#&#8203;6117</a>)</li>
<li><code>[jest-validate]</code> Get rid of <code>jest-config</code> dependency (<a href="https://renovatebot.com/gh/facebook/jest/pull/6067">#&#8203;6067</a>)</li>
<li><code>[jest-validate]</code> Adds option to inject <code>deprecationEntries</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6067">#&#8203;6067</a>)</li>
<li><code>[jest-snapshot]</code> [<strong>BREAKING</strong>] Concatenate name of test, optional snapshot name and count (<a href="https://renovatebot.com/gh/facebook/jest/pull/6015">#&#8203;6015</a>)</li>
<li><code>[jest-runtime]</code> Allow for transform plugins to skip the definition process method if createTransformer method was defined. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5999">#&#8203;5999</a>)</li>
<li><code>[expect]</code> Add stack trace for async errors (<a href="https://renovatebot.com/gh/facebook/jest/pull/6008">#&#8203;6008</a>)</li>
<li><code>[jest-jasmine2]</code> Add stack trace for timeouts (<a href="https://renovatebot.com/gh/facebook/jest/pull/6008">#&#8203;6008</a>)</li>
<li><code>[jest-jasmine2]</code> Add stack trace for thrown non-<code>Error</code>s (<a href="https://renovatebot.com/gh/facebook/jest/pull/6008">#&#8203;6008</a>)</li>
<li><code>[jest-runtime]</code> Prevent modules from marking themselves as their own parent (<a href="https://renovatebot.com/gh/facebook/jest/issues/5235">#&#8203;5235</a>)</li>
<li><code>[jest-mock]</code> Add support for auto-mocking generator functions (<a href="https://renovatebot.com/gh/facebook/jest/pull/5983">#&#8203;5983</a>)</li>
<li><code>[expect]</code> Add support for async matchers  (<a href="https://renovatebot.com/gh/facebook/jest/pull/5919">#&#8203;5919</a>)</li>
<li><code>[expect]</code> Suggest toContainEqual (<a href="https://renovatebot.com/gh/facebook/jest/pull/5953">#&#8203;5948</a>)</li>
<li><code>[jest-config]</code> Export Jest's default options (<a href="https://renovatebot.com/gh/facebook/jest/pull/5948">#&#8203;5948</a>)</li>
<li><code>[jest-editor-support]</code> Move <code>coverage</code> to <code>ProjectWorkspace.collectCoverage</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5929">#&#8203;5929</a>)</li>
<li><code>[jest-editor-support]</code> Add <code>coverage</code> option to runner (<a href="https://renovatebot.com/gh/facebook/jest/pull/5836">#&#8203;5836</a>)</li>
<li><code>[jest-haste-map]</code> Support extracting dynamic <code>import</code>s (<a href="https://renovatebot.com/gh/facebook/jest/pull/5883">#&#8203;5883</a>)</li>
<li><code>[expect]</code> Improve output format for mismatchedArgs in mock/spy calls. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5846">#&#8203;5846</a>)</li>
<li><code>[jest-cli]</code> Add support for using <code>--coverage</code> in combination with watch mode, <code>--onlyChanged</code>, <code>--findRelatedTests</code> and more (<a href="https://renovatebot.com/gh/facebook/jest/pull/5601">#&#8203;5601</a>)</li>
<li><code>[jest-jasmine2]</code> [<strong>BREAKING</strong>] Adds error throwing and descriptive errors to <code>it</code>/ <code>test</code> for invalid arguments. <code>[jest-circus]</code> Adds error throwing and descriptive errors to <code>it</code>/ <code>test</code> for invalid arguments (<a href="https://renovatebot.com/gh/facebook/jest/pull/5558">#&#8203;5558</a>)</li>
<li><code>[jest-matcher-utils]</code> Add <code>isNot</code> option to <code>matcherHint</code> function (<a href="https://renovatebot.com/gh/facebook/jest/pull/5512">#&#8203;5512</a>)</li>
<li><code>[jest-config]</code> Add <code>&lt;rootDir&gt;</code> to runtime files not found error report (<a href="https://renovatebot.com/gh/facebook/jest/pull/5693">#&#8203;5693</a>)</li>
<li><code>[expect]</code> Make toThrow matcher pass only if Error object is returned from promises (<a href="https://renovatebot.com/gh/facebook/jest/pull/5670">#&#8203;5670</a>)</li>
<li><code>[expect]</code> Add isError to utils (<a href="https://renovatebot.com/gh/facebook/jest/pull/5670">#&#8203;5670</a>)</li>
<li><code>[expect]</code> Add inverse matchers (<code>expect.not.arrayContaining</code>, etc., <a href="https://renovatebot.com/gh/facebook/jest/pull/5517">#&#8203;5517</a>)</li>
<li><code>[expect]</code> <code>expect.extend</code> now also extends asymmetric matchers (<a href="https://renovatebot.com/gh/facebook/jest/pull/5503">#&#8203;5503</a>)</li>
<li><code>[jest-mock]</code> Update <code>spyOnProperty</code> to support spying on the prototype chain (<a href="https://renovatebot.com/gh/facebook/jest/pull/5753">#&#8203;5753</a>)</li>
<li><code>[jest-mock]</code> Add tracking of return values in the <code>mock</code> property (<a href="https://renovatebot.com/gh/facebook/jest/pull/5752">#&#8203;5752</a>)</li>
<li><code>[jest-mock]</code> Add tracking of thrown errors in the <code>mock</code> property (<a href="https://renovatebot.com/gh/facebook/jest/pull/5764">#&#8203;5764</a>)</li>
<li><code>[expect]</code>Add nthCalledWith spy matcher (<a href="https://renovatebot.com/gh/facebook/jest/pull/5605">#&#8203;5605</a>)</li>
<li><code>[jest-cli]</code> Add <code>isSerial</code> property that runners can expose to specify that they can not run in parallel (<a href="https://renovatebot.com/gh/facebook/jest/pull/5706">#&#8203;5706</a>)</li>
<li><code>[expect]</code> Add <code>.toBeCalledTimes</code> and <code>toHaveBeenNthCalledWith</code> aliases (<a href="https://renovatebot.com/gh/facebook/jest/pull/5826">#&#8203;5826</a>)</li>
<li><code>[jest-cli]</code> Interactive Snapshot Mode improvements (<a href="https://renovatebot.com/gh/facebook/jest/pull/5864">#&#8203;5864</a>)</li>
<li><code>[jest-editor-support]</code> Add <code>no-color</code> option to runner (<a href="https://renovatebot.com/gh/facebook/jest/pull/5909">#&#8203;5909</a>)</li>
<li><code>[jest-jasmine2]</code> Pretty-print non-Error object errors (<a href="https://renovatebot.com/gh/facebook/jest/pull/5980">#&#8203;5980</a>)</li>
<li><code>[jest-message-util]</code> Include column in stack frames (<a href="https://renovatebot.com/gh/facebook/jest/pull/5889">#&#8203;5889</a>)</li>
<li><code>[expect]</code> Introduce toStrictEqual (<a href="https://renovatebot.com/gh/facebook/jest/pull/6032">#&#8203;6032</a>)</li>
<li><code>[expect]</code> Add return matchers (<a href="https://renovatebot.com/gh/facebook/jest/pull/5879">#&#8203;5879</a>)</li>
<li><code>[jest-cli]</code> Improve snapshot summaries (<a href="https://renovatebot.com/gh/facebook/jest/pull/6181">#&#8203;6181</a>)</li>
<li><code>[expect]</code> Include custom mock names in error messages (<a href="https://renovatebot.com/gh/facebook/jest/pull/6199">#&#8203;6199</a>)</li>
<li><code>[jest-diff]</code> Support returning diff from oneline strings (<a href="https://renovatebot.com/gh/facebook/jest/pull/6221">#&#8203;6221</a>)</li>
<li><code>[expect]</code> Improve return matchers (<a href="https://renovatebot.com/gh/facebook/jest/pull/6172">#&#8203;6172</a>)</li>
<li><code>[jest-cli]</code> Overhaul watch plugin hooks names (<a href="https://renovatebot.com/gh/facebook/jest/pull/6249">#&#8203;6249</a>)</li>
<li><code>[jest-mock]</code> Include tracked call results in serialized mock (<a href="https://renovatebot.com/gh/facebook/jest/pull/6244">#&#8203;6244</a>)</li>
</ul>
<h5 id="fixes-7">Fixes</h5>
<ul>
<li><code>[jest-cli]</code> Fix stdin encoding to utf8 for watch plugins. (<a href="https://renovatebot.com/gh/facebook/jest/issues/6253">#&#8203;6253</a>)</li>
<li><code>[expect]</code> Better detection of DOM Nodes for equality (<a href="https://renovatebot.com/gh/facebook/jest/pull/6246">#&#8203;6246</a>)</li>
<li><code>[jest-cli]</code> Fix misleading action description for F key when in "only failed tests" mode. (<a href="https://renovatebot.com/gh/facebook/jest/issues/6167">#&#8203;6167</a>)</li>
<li><code>[jest-worker]</code> Stick calls to workers before processing them (<a href="https://renovatebot.com/gh/facebook/jest/pull/6073">#&#8203;6073</a>)</li>
<li><code>[babel-plugin-jest-hoist]</code> Allow using <code>console</code> global variable (<a href="https://renovatebot.com/gh/facebook/jest/pull/6075">#&#8203;6075</a>)</li>
<li><code>[jest-jasmine2]</code> Always remove node core message from assert stack traces (<a href="https://renovatebot.com/gh/facebook/jest/pull/6055">#&#8203;6055</a>)</li>
<li><code>[expect]</code> Add stack trace when <code>expect.assertions</code> and <code>expect.hasAssertions</code> causes test failures. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5997">#&#8203;5997</a>)</li>
<li><code>[jest-runtime]</code> Throw a more useful error when trying to require modules after the test environment is torn down (<a href="https://renovatebot.com/gh/facebook/jest/pull/5888">#&#8203;5888</a>)</li>
<li><code>[jest-mock]</code> [<strong>BREAKING</strong>] Replace timestamps with <code>invocationCallOrder</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5867">#&#8203;5867</a>)</li>
<li><code>[jest-jasmine2]</code> Install <code>sourcemap-support</code> into normal runtime to catch runtime errors (<a href="https://renovatebot.com/gh/facebook/jest/pull/5945">#&#8203;5945</a>)</li>
<li><code>[jest-jasmine2]</code> Added assertion error handling inside <code>afterAll hook</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5884">#&#8203;5884</a>)</li>
<li><code>[jest-cli]</code> Remove the notifier actions in case of failure when not in watch mode. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5861">#&#8203;5861</a>)</li>
<li><code>[jest-mock]</code> Extend .toHaveBeenCalled return message with outcome (<a href="https://renovatebot.com/gh/facebook/jest/pull/5951">#&#8203;5951</a>)</li>
<li><code>[jest-runner]</code> Assign <code>process.env.JEST_WORKER_ID="1"</code> when in runInBand mode (<a href="https://renovatebot.com/gh/facebook/jest/pull/5860">#&#8203;5860</a>)</li>
<li><code>[jest-cli]</code> Add descriptive error message when trying to use <code>globalSetup</code>/<code>globalTeardown</code> file that doesn't export a function. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5835">#&#8203;5835</a>)</li>
<li><code>[expect]</code> Do not rely on <code>instanceof RegExp</code>, since it will not work for RegExps created inside of a different VM (<a href="https://renovatebot.com/gh/facebook/jest/pull/5729">#&#8203;5729</a>)</li>
<li><code>[jest-resolve]</code> Update node module resolution algorithm to correctly handle symlinked paths (<a href="https://renovatebot.com/gh/facebook/jest/pull/5085">#&#8203;5085</a>)</li>
<li><code>[jest-editor-support]</code> Update <code>Settings</code> to use spawn in shell option (<a href="https://renovatebot.com/gh/facebook/jest/pull/5658">#&#8203;5658</a>)</li>
<li><code>[jest-cli]</code> Improve the error message when 2 projects resolve to the same config (<a href="https://renovatebot.com/gh/facebook/jest/pull/5674">#&#8203;5674</a>)</li>
<li><code>[jest-runtime]</code> remove retainLines from coverage instrumentation (<a href="https://renovatebot.com/gh/facebook/jest/pull/5692">#&#8203;5692</a>)</li>
<li><code>[jest-cli]</code> Fix update snapshot issue when using watchAll (<a href="https://renovatebot.com/gh/facebook/jest/pull/5696">#&#8203;5696</a>)</li>
<li><code>[expect]</code> Fix rejects.not matcher (<a href="https://renovatebot.com/gh/facebook/jest/pull/5670">#&#8203;5670</a>)</li>
<li><code>[jest-runtime]</code> Prevent Babel warnings on large files (<a href="https://renovatebot.com/gh/facebook/jest/pull/5702">#&#8203;5702</a>)</li>
<li><code>[jest-mock]</code> Prevent <code>mockRejectedValue</code> from causing unhandled rejection (<a href="https://renovatebot.com/gh/facebook/jest/pull/5720">#&#8203;5720</a>)</li>
<li><code>[pretty-format]</code> Handle React fragments better (<a href="https://renovatebot.com/gh/facebook/jest/pull/5816">#&#8203;5816</a>)</li>
<li><code>[pretty-format]</code> Handle formatting of <code>React.forwardRef</code> and <code>Context</code> components (<a href="https://renovatebot.com/gh/facebook/jest/pull/6093">#&#8203;6093</a>)</li>
<li><code>[jest-cli]</code> Switch collectCoverageFrom back to a string (<a href="https://renovatebot.com/gh/facebook/jest/pull/5914">#&#8203;5914</a>)</li>
<li><code>[jest-regex-util]</code> Fix handling regex symbols in tests path on Windows (<a href="https://renovatebot.com/gh/facebook/jest/pull/5941">#&#8203;5941</a>)</li>
<li><code>[jest-util]</code> Fix handling of NaN/Infinity in mock timer delay (<a href="https://renovatebot.com/gh/facebook/jest/pull/5966">#&#8203;5966</a>)</li>
<li><code>[jest-resolve]</code> Generalise test for package main entries equivalent to ".". (<a href="https://renovatebot.com/gh/facebook/jest/pull/5968">#&#8203;5968</a>)</li>
<li><code>[jest-config]</code> Ensure that custom resolvers are used when resolving the configuration (<a href="https://renovatebot.com/gh/facebook/jest/pull/5976">#&#8203;5976</a>)</li>
<li><code>[website]</code> Fix website docs (<a href="https://renovatebot.com/gh/facebook/jest/pull/5853">#&#8203;5853</a>)</li>
<li><code>[expect]</code> Fix isEqual Set and Map to compare object values and keys regardless of order (<a href="https://renovatebot.com/gh/facebook/jest/pull/6150">#&#8203;6150</a>)</li>
<li><code>[pretty-format]</code> [<strong>BREAKING</strong>] Remove undefined props from React elements (<a href="https://renovatebot.com/gh/facebook/jest/pull/6162">#&#8203;6162</a>)</li>
<li><code>[jest-haste-map]</code> Properly resolve mocked node modules without package.json defined (<a href="https://renovatebot.com/gh/facebook/jest/pull/6232">#&#8203;6232</a>)</li>
</ul>
<h5 id="chore--maintenance-4">Chore &amp; Maintenance</h5>
<ul>
<li><code>[jest-runner]</code> Move sourcemap installation from <code>jest-jasmine2</code> to <code>jest-runner</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6176">#&#8203;6176</a>)</li>
<li><code>[jest-cli]</code> Use yargs's built-in <code>version</code> instead of rolling our own (<a href="https://renovatebot.com/gh/facebook/jest/pull/6215">#&#8203;6215</a>)</li>
<li><code>[docs]</code> Add explanation on how to mock methods not implemented in JSDOM</li>
<li><code>[jest-jasmine2]</code> Simplify <code>Env.execute</code> and TreeProcessor to setup and clean resources for the top suite the same way as for all of the children suites (<a href="https://renovatebot.com/gh/facebook/jest/pull/5885">#&#8203;5885</a>)</li>
<li><code>[babel-jest]</code> [<strong>BREAKING</strong>] Always return object from transformer (<a href="https://renovatebot.com/gh/facebook/jest/pull/5991">#&#8203;5991</a>)</li>
<li><code>[*]</code> Run Prettier on compiled output (<a href="https://renovatebot.com/gh/facebook/jest/pull/3497">#&#8203;5858</a>)</li>
<li><code>[jest-cli]</code> Add fileChange hook for plugins (<a href="https://renovatebot.com/gh/facebook/jest/pull/5708">#&#8203;5708</a>)</li>
<li><code>[docs]</code> Add docs on using <code>jest.mock(...)</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5648">#&#8203;5648</a>)</li>
<li><code>[docs]</code> Mention Jest Puppeteer Preset (<a href="https://renovatebot.com/gh/facebook/jest/pull/5722">#&#8203;5722</a>)</li>
<li><code>[docs]</code> Add jest-community section to website (<a href="https://renovatebot.com/gh/facebook/jest/pull/5675">#&#8203;5675</a>)</li>
<li><code>[docs]</code> Add versioned docs for v22.4 (<a href="https://renovatebot.com/gh/facebook/jest/pull/5733">#&#8203;5733</a>)</li>
<li><code>[docs]</code> Improve Snapshot Testing Guide (<a href="https://renovatebot.com/gh/facebook/jest/issues/5812">#&#8203;5812</a>)</li>
<li><code>[jest-runtime]</code> [<strong>BREAKING</strong>] Remove <code>jest.genMockFn</code> and <code>jest.genMockFunction</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6173">#&#8203;6173</a>)</li>
<li><code>[jest-message-util]</code> Avoid adding unnecessary indent to blank lines in stack traces (<a href="https://renovatebot.com/gh/facebook/jest/pull/6211">#&#8203;6211</a>)</li>
</ul>
<hr />
<h3 id="v2244httpsgithubcomfacebookjestcompare6851d8bc9d67e83fb1bb0199d28ef84565938225v2244"><a href="https://renovatebot.com/gh/facebook/jest/compare/6851d8bc9d67e83fb1bb0199d28ef84565938225…v22.4.4"><code>v22.4.4</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/6851d8bc9d67e83fb1bb0199d28ef84565938225…v22.4.4">Compare Source</a></p>
<hr />
<h3 id="v2243httpsgithubcomfacebookjestcomparev22426851d8bc9d67e83fb1bb0199d28ef84565938225"><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.4.2…6851d8bc9d67e83fb1bb0199d28ef84565938225"><code>v22.4.3</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.4.2…6851d8bc9d67e83fb1bb0199d28ef84565938225">Compare Source</a></p>
<hr />
<h3 id="v2242httpsgithubcomfacebookjestblobmasterchangelogmd82032242"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2242"><code>v22.4.2</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.4.1…v22.4.2">Compare Source</a></p>
<h5 id="fixes-8">Fixes</h5>
<ul>
<li><code>[jest-haste-map]</code> Recreate Haste map when deserialization fails (<a href="https://renovatebot.com/gh/facebook/jest/pull/5642">#&#8203;5642</a>)</li>
</ul>
<hr />
<h3 id="v2241httpsgithubcomfacebookjestblobmasterchangelogmd82032241"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2241"><code>v22.4.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.4.0…v22.4.1">Compare Source</a></p>
<h5 id="fixes-9">Fixes</h5>
<ul>
<li><code>[jest-haste-map]</code> Parallelize Watchman calls in crawler (<a href="https://renovatebot.com/gh/facebook/jest/pull/5640">#&#8203;5640</a>)</li>
<li><code>[jest-editor-support]</code> Update TypeScript definitions (<a href="https://renovatebot.com/gh/facebook/jest/pull/5625">#&#8203;5625</a>)</li>
<li><code>[babel-jest]</code> Remove <code>retainLines</code> argument to babel. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5594">#&#8203;5594</a>)</li>
</ul>
<h5 id="features-6">Features</h5>
<ul>
<li><code>[jest-runtime]</code> Provide <code>require.main</code> property set to module with test suite (<a href="https://renovatebot.com/gh/facebook/jest/pull/5618">#&#8203;5618</a>)</li>
</ul>
<h5 id="chore--maintenance-5">Chore &amp; Maintenance</h5>
<ul>
<li><code>[docs]</code> Add note about Node version support (<a href="https://renovatebot.com/gh/facebook/jest/pull/5622">#&#8203;5622</a>)</li>
<li><code>[docs]</code> Update to use yarn (<a href="https://renovatebot.com/gh/facebook/jest/pull/5624">#&#8203;5624</a>)</li>
<li><code>[docs]</code> Add how to mock scoped modules to Manual Mocks doc (<a href="https://renovatebot.com/gh/facebook/jest/pull/5638">#&#8203;5638</a>)</li>
</ul>
<hr />
<h3 id="v2240httpsgithubcomfacebookjestblobmasterchangelogmd82032240"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2240"><code>v22.4.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.3.0…v22.4.0">Compare Source</a></p>
<h5 id="fixes-10">Fixes</h5>
<ul>
<li><code>[jest-haste-map]</code> Overhauls how Watchman crawler works fixing Windows (<a href="https://renovatebot.com/gh/facebook/jest/pull/5615">#&#8203;5615</a>)</li>
<li><code>[expect]</code> Allow matching of Errors against plain objects (<a href="https://renovatebot.com/gh/facebook/jest/pull/5611">#&#8203;5611</a>)</li>
<li><code>[jest-haste-map]</code> Do not read binary files in Haste, even when instructed to do so (<a href="https://renovatebot.com/gh/facebook/jest/pull/5612">#&#8203;5612</a>)</li>
<li><code>[jest-cli]</code> Don't skip matchers for exact files (<a href="https://renovatebot.com/gh/facebook/jest/pull/5582">#&#8203;5582</a>)</li>
<li><code>[docs]</code> Update discord links (<a href="https://renovatebot.com/gh/facebook/jest/pull/5586">#&#8203;5586</a>)</li>
<li><code>[jest-runtime]</code> Align handling of testRegex on Windows between searching for tests and instrumentation checks (<a href="https://renovatebot.com/gh/facebook/jest/pull/5560">#&#8203;5560</a>)</li>
<li><code>[jest-config]</code> Make it possible to merge <code>transform</code> option with preset (<a href="https://renovatebot.com/gh/facebook/jest/pull/5505">#&#8203;5505</a>)</li>
<li><code>[jest-util]</code> Fix <code>console.assert</code> behavior in custom &amp; buffered consoles (<a href="https://renovatebot.com/gh/facebook/jest/pull/5576">#&#8203;5576</a>)</li>
</ul>
<h5 id="features-7">Features</h5>
<ul>
<li><code>[docs]</code> Add MongoDB guide (<a href="https://renovatebot.com/gh/facebook/jest/pull/5571">#&#8203;5571</a>)</li>
<li><code>[jest-runtime]</code> Deprecate mapCoverage option. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5177">#&#8203;5177</a>)</li>
<li><code>[babel-jest]</code> Add option to return sourcemap from the transformer separately from source. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5177">#&#8203;5177</a>)</li>
<li><code>[jest-validate]</code> Add ability to log deprecation warnings for CLI flags. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5536">#&#8203;5536</a>)</li>
<li><code>[jest-serializer]</code> Added new module for serializing. Works using V8 or JSON (<a href="https://renovatebot.com/gh/facebook/jest/pull/5609">#&#8203;5609</a>)</li>
<li><code>[docs]</code> Add a documentation note for project <code>displayName</code> configuration (<a href="https://renovatebot.com/gh/facebook/jest/pull/5600">#&#8203;5600</a>)</li>
</ul>
<h5 id="chore--maintenance-6">Chore &amp; Maintenance</h5>
<ul>
<li><code>[docs]</code> Update automatic mocks documentation (<a href="https://renovatebot.com/gh/facebook/jest/pull/5630">#&#8203;5630</a>)</li>
</ul>
<hr />
<h3 id="v2230httpsgithubcomfacebookjestblobmasterchangelogmdjest-2230"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2230"><code>v22.3.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.2.2…v22.3.0">Compare Source</a></p>
<h5 id="fixes-11">Fixes</h5>
<ul>
<li><code>[expect]</code> Add descriptive error message to CalledWith methods when missing optional arguments (<a href="https://renovatebot.com/gh/facebook/jest/pull/5547">#&#8203;5547</a>)</li>
<li><code>[jest-cli]</code> Fix inability to quit watch mode while debugger is still attached (<a href="https://renovatebot.com/gh/facebook/jest/pull/5029">#&#8203;5029</a>)</li>
<li><code>[jest-haste-map]</code> Properly handle platform-specific file deletions (<a href="https://renovatebot.com/gh/facebook/jest/pull/5534">#&#8203;5534</a>)</li>
</ul>
<h5 id="features-8">Features</h5>
<ul>
<li><code>[jest-util]</code> Add the following methods to the "console" implementations: <code>assert</code>, <code>count</code>, <code>countReset</code>, <code>dir</code>, <code>dirxml</code>, <code>group</code>, <code>groupCollapsed</code>, <code>groupEnd</code>, <code>time</code>, <code>timeEnd</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5514">#&#8203;5514</a>)</li>
<li><code>[docs]</code> Add documentation for interactive snapshot mode (<a href="https://renovatebot.com/gh/facebook/jest/pull/5291">#&#8203;5291</a>)</li>
<li><code>[jest-editor-support]</code> Add watchAll flag (<a href="https://renovatebot.com/gh/facebook/jest/pull/5523">#&#8203;5523</a>)</li>
<li><code>[jest-cli]</code> Support multiple glob patterns for <code>collectCoverageFrom</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5537">#&#8203;5537</a>)</li>
<li><code>[docs]</code> Add versioned documentation to the website (<a href="https://renovatebot.com/gh/facebook/jest/pull/5541">#&#8203;5541</a>)</li>
</ul>
<h5 id="chore--maintenance-7">Chore &amp; Maintenance</h5>
<ul>
<li><code>[jest-config]</code> Allow <code>&lt;rootDir&gt;</code> to be used with <code>collectCoverageFrom</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5524">#&#8203;5524</a>)</li>
<li><code>[filenames]</code> Standardize files names in "integration-tests" folder (<a href="https://renovatebot.com/gh/facebook/jest/pull/5513">#&#8203;5513</a>)</li>
</ul>
<hr />
<h3 id="v2222httpsgithubcomfacebookjestblobmasterchangelogmdjest-2222"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2222"><code>v22.2.2</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.2.1…v22.2.2">Compare Source</a></p>
<h5 id="fixes-12">Fixes</h5>
<ul>
<li><code>[babel-jest]</code> Revert "Remove retainLines from babel-jest" (<a href="https://renovatebot.com/gh/facebook/jest/pull/5496">#&#8203;5496</a>)</li>
<li><code>[jest-docblock]</code> Support multiple of the same <code>@pragma</code>. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5502">#&#8203;5154</a>)</li>
</ul>
<h5 id="features-9">Features</h5>
<ul>
<li><code>[jest-worker]</code> Assign a unique id for each worker and pass it to the child process. It will be available via <code>process.env.JEST_WORKER_ID</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5494">#&#8203;5494</a>)</li>
</ul>
<h5 id="chore--maintenance-8">Chore &amp; Maintenance</h5>
<ul>
<li><code>[filenames]</code> Standardize file names in root (<a href="https://renovatebot.com/gh/facebook/jest/pull/5500">#&#8203;5500</a>)</li>
</ul>
<hr />
<h3 id="v2221httpsgithubcomfacebookjestblobmasterchangelogmdjest-2221"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2221"><code>v22.2.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.2.0…v22.2.1">Compare Source</a></p>
<h5 id="fixes-13">Fixes</h5>
<ul>
<li><code>[jest-config]</code> "all" takes precedence over "lastCommit" (<a href="https://renovatebot.com/gh/facebook/jest/pull/5486">#&#8203;5486</a>)</li>
</ul>
<hr />
<h3 id="v2220httpsgithubcomfacebookjestblobmasterchangelogmdjest-2220"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2220"><code>v22.2.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.1.4…v22.2.0">Compare Source</a></p>
<h5 id="features-10">Features</h5>
<ul>
<li><code>[jest-runner]</code> Move test summary to after coverage report (<a href="https://renovatebot.com/gh/facebook/jest/pull/4512">#&#8203;4512</a>)</li>
<li><code>[jest-cli]</code> Added <code>--notifyMode</code> to specify when to be notified. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5125">#&#8203;5125</a>)</li>
<li><code>[diff-sequences]</code> New package compares items in two sequences to find a <strong>longest common subsequence</strong>. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5407">#&#8203;5407</a>)</li>
<li><code>[jest-matcher-utils]</code> Add <code>comment</code> option to <code>matcherHint</code> function (<a href="https://renovatebot.com/gh/facebook/jest/pull/5437">#&#8203;5437</a>)</li>
<li><code>[jest-config]</code> Allow lastComit and changedFilesWithAncestor via JSON config (<a href="https://renovatebot.com/gh/facebook/jest/pull/5476">#&#8203;5476</a>)</li>
<li><code>[jest-util]</code> Add deletion to <code>process.env</code> as well (<a href="https://renovatebot.com/gh/facebook/jest/pull/5466">#&#8203;5466</a>)</li>
<li><code>[jest-util]</code> Add case-insensitive getters/setters to <code>process.env</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5465">#&#8203;5465</a>)</li>
<li><code>[jest-mock]</code> Add util methods to create async functions. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5318">#&#8203;5318</a>)</li>
</ul>
<h5 id="fixes-14">Fixes</h5>
<ul>
<li><code>[jest-cli]</code> Add trailing slash when checking root folder (<a href="https://renovatebot.com/gh/facebook/jest/pull/5464">#&#8203;5464</a>)</li>
<li><code>[jest-cli]</code> Hide interactive mode if there are no failed snapshot tests (<a href="https://renovatebot.com/gh/facebook/jest/pull/5450">#&#8203;5450</a>)</li>
<li><code>[babel-jest]</code> Remove retainLines from babel-jest (<a href="https://renovatebot.com/gh/facebook/jest/pull/5439">#&#8203;5439</a>)</li>
<li><code>[jest-cli]</code> Glob patterns ignore non-<code>require</code>-able files (e.g. <code>README.md</code>) (<a href="https://renovatebot.com/gh/facebook/jest/issues/5199">#&#8203;5199</a>)</li>
<li><code>[jest-mock]</code> Add backticks support (``) to <code>mock</code> a certain package via the <code>__mocks__</code> folder. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5426">#&#8203;5426</a>)</li>
<li><code>[jest-message-util]</code> Prevent an <code>ENOENT</code> crash when the test file contained a malformed source-map. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5405">#&#8203;5405</a>).</li>
<li><code>[jest]</code> Add <code>import-local</code> to <code>jest</code> package. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5353">#&#8203;5353</a>)</li>
<li><code>[expect]</code> Support class instances in <code>.toHaveProperty()</code> and <code>.toMatchObject</code> matcher. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5367">#&#8203;5367</a>)</li>
<li><code>[jest-cli]</code> Fix npm update command for snapshot summary. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5376">#&#8203;5376</a>, <a href="https://renovatebot.com/gh/facebook/jest/pull/5389/">5389</a>)</li>
<li><code>[expect]</code> Make <code>rejects</code> and <code>resolves</code> synchronously validate its argument. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5364">#&#8203;5364</a>)</li>
<li><code>[docs]</code> Add tutorial page for ES6 class mocks. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5383">#&#8203;5383</a>)</li>
<li><code>[jest-resolve]</code> Search required modules in node_modules and then in custom paths. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5403">#&#8203;5403</a>)</li>
<li><code>[jest-resolve]</code> Get builtin modules from node core. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5411">#&#8203;5411</a>)</li>
<li><code>[jest-resolve]</code> Detect and preserve absolute paths in <code>moduleDirectories</code>. Do not generate additional (invalid) paths by prepending each ancestor of <code>cwd</code> to the absolute path. Additionally, this fixes functionality in Windows OS. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5398">#&#8203;5398</a>)</li>
</ul>
<h5 id="chore--maintenance-9">Chore &amp; Maintenance</h5>
<ul>
<li><code>[jest-util]</code> Implement watch plugins (<a href="https://renovatebot.com/gh/facebook/jest/pull/5399">#&#8203;5399</a>)</li>
</ul>
<hr />
<h3 id="v2214httpsgithubcomfacebookjestblobmasterchangelogmdjest-2214"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2214"><code>v22.1.4</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.1.3…v22.1.4">Compare Source</a></p>
<h5 id="fixes-15">Fixes</h5>
<ul>
<li><code>[jest-util]</code> Add "debug" method to "console" implementations (<a href="https://renovatebot.com/gh/facebook/jest/pull/5350">#&#8203;5350</a>)</li>
<li><code>[jest-resolve]</code> Add condition to avoid infinite loop when node module package main is ".". (<a href="https://renovatebot.com/gh/facebook/jest/pull/5344">#&#8203;5344)</a></li>
</ul>
<h5 id="features-11">Features</h5>
<ul>
<li><code>[jest-cli]</code> <code>--changedSince</code>: allow selectively running tests for code changed since arbitrary revisions. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5312">#&#8203;5312</a>)</li>
</ul>
<hr />
<h3 id="v2213httpsgithubcomfacebookjestblobmasterchangelogmdjest-2213"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2213"><code>v22.1.3</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.1.2…v22.1.3">Compare Source</a></p>
<h5 id="fixes-16">Fixes</h5>
<ul>
<li><code>[jest-cli]</code> Check if the file belongs to the checked project before adding it to the list, also checking that the file name is not explicitly blacklisted (<a href="https://renovatebot.com/gh/facebook/jest/pull/5341">#&#8203;5341</a>)</li>
<li><code>[jest-editor-support]</code> Add option to spawn command in shell (<a href="https://renovatebot.com/gh/facebook/jest/pull/5340">#&#8203;5340</a>)</li>
</ul>
<hr />
<h3 id="v2212httpsgithubcomfacebookjestblobmasterchangelogmdjest-2212"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2212"><code>v22.1.2</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.1.1…v22.1.2">Compare Source</a></p>
<h5 id="fixes-17">Fixes</h5>
<ul>
<li><code>[jest-cli]</code> Check if the file belongs to the checked project before adding it to the list (<a href="https://renovatebot.com/gh/facebook/jest/pull/5335">#&#8203;5335</a>)</li>
<li><code>[jest-cli]</code> Fix <code>EISDIR</code> when a directory is passed as an argument to <code>jest</code>. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5317">#&#8203;5317</a>)</li>
<li><code>[jest-config]</code> Added restoreMocks config option. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5327">#&#8203;5327</a>)</li>
</ul>
<hr />
<h3 id="v2211httpsgithubcomfacebookjestblobmasterchangelogmdjest-2211"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2211"><code>v22.1.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.1.0…v22.1.1">Compare Source</a></p>
<h5 id="fixes-18">Fixes</h5>
<ul>
<li><code>[*]</code> Move from "process.exit" to "exit. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5313">#&#8203;5313</a>)</li>
</ul>
<hr />
<h3 id="v2210httpsgithubcomfacebookjestblobmasterchangelogmdjest-2210"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2210"><code>v22.1.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/4bcfe19b89b445bec793ba0a2ac815d117fa8098…v22.1.0">Compare Source</a></p>
<h5 id="features-12">Features</h5>
<ul>
<li><code>[jest-cli]</code> Make Jest exit without an error when no tests are found in the case of <code>--lastCommit</code>, <code>--findRelatedTests</code>, or <code>--onlyChanged</code> options having been passed to the CLI</li>
<li><code>[jest-cli]</code> Add interactive snapshot mode (<a href="https://renovatebot.com/gh/facebook/jest/pull/3831">#&#8203;3831</a>)</li>
</ul>
<h5 id="fixes-19">Fixes</h5>
<ul>
<li><code>[jest-cli]</code> Use <code>import-local</code> to support global Jest installations. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5304">#&#8203;5304</a>)</li>
<li><code>[jest-runner]</code> Fix memory leak in coverage reporting (<a href="https://renovatebot.com/gh/facebook/jest/pull/5289">#&#8203;5289</a>)</li>
<li><code>[docs]</code> Update mention of the minimal version of node supported (<a href="https://renovatebot.com/gh/facebook/jest/issues/4947">#&#8203;4947</a>)</li>
<li><code>[jest-cli]</code> Fix missing newline in console message (<a href="https://renovatebot.com/gh/facebook/jest/pull/5308">#&#8203;5308</a>)</li>
<li><code>[jest-cli]</code> <code>--lastCommit</code> and <code>--changedFilesWithAncestor</code> now take effect even when <code>--onlyChanged</code> is not specified. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5307">#&#8203;5307</a>)</li>
</ul>
<h5 id="chore--maintenance-10">Chore &amp; Maintenance</h5>
<ul>
<li><code>[filenames]</code> Standardize folder names under <code>integration-tests/</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5298">#&#8203;5298</a>)</li>
</ul>
<hr />
<h3 id="v2206httpsgithubcomfacebookjestblobmasterchangelogmdjest-2206"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2206"><code>v22.0.6</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.0.5…4bcfe19b89b445bec793ba0a2ac815d117fa8098">Compare Source</a></p>
<h5 id="fixes-20">Fixes</h5>
<ul>
<li><code>[jest-jasmine2]</code> Fix memory leak in snapshot reporting (<a href="https://renovatebot.com/gh/facebook/jest/pull/5279">#&#8203;5279</a>)</li>
<li><code>[jest-config]</code> Fix breaking change in <code>--testPathPattern</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5269">#&#8203;5269</a>)</li>
<li><code>[docs]</code> Document caveat with mocks, Enzyme, snapshots and React 16 (<a href="https://renovatebot.com/gh/facebook/jest/issues/5258">#&#8203;5258</a>)</li>
</ul>
<hr />
<h3 id="v2205httpsgithubcomfacebookjestblobmasterchangelogmdjest-2205"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2205"><code>v22.0.5</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.0.4…v22.0.5">Compare Source</a></p>
<h5 id="fixes-21">Fixes</h5>
<ul>
<li><code>[jest-leak-detector]</code> Removed the reference to <code>weak</code>. Now, parent projects must install it by hand for the module to work.</li>
<li><code>[expect]</code> Fail test when the types of <code>stringContaining</code> and <code>stringMatching</code> matchers do not match. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5069">#&#8203;5069</a>)</li>
<li><code>[jest-cli]</code> Treat dumb terminals as noninteractive (<a href="https://renovatebot.com/gh/facebook/jest/pull/5237">#&#8203;5237</a>)</li>
<li><code>[jest-cli]</code> <code>jest --onlyChanged --changedFilesWithAncestor</code> now also works with git. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5189">#&#8203;5189</a>)</li>
<li><code>[jest-config]</code> fix unexpected condition to avoid infinite recursion in Windows platform. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5161">#&#8203;5161</a>)</li>
<li><code>[jest-config]</code> Escape parentheses and other glob characters in <code>rootDir</code> before interpolating with <code>testMatch</code>. (<a href="https://renovatebot.com/gh/facebook/jest/issues/4838">#&#8203;4838</a>)</li>
<li><code>[jest-regex-util]</code> Fix breaking change in <code>--testPathPattern</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5230">#&#8203;5230</a>)</li>
<li><code>[expect]</code> Do not override <code>Error</code> stack (with <code>Error.captureStackTrace</code>) for custom matchers. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5162">#&#8203;5162</a>)</li>
<li><code>[pretty-format]</code> Pretty format for DOMStringMap and NamedNodeMap (<a href="https://renovatebot.com/gh/facebook/jest/pull/5233">#&#8203;5233</a>)</li>
<li><code>[jest-cli]</code> Use a better console-clearing string on Windows (<a href="https://renovatebot.com/gh/facebook/jest/pull/5251">#&#8203;5251</a>)</li>
</ul>
<h5 id="features-13">Features</h5>
<ul>
<li><code>[jest-jasmine]</code> Allowed classes and functions as <code>describe</code> names. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5154">#&#8203;5154</a>)</li>
<li><code>[jest-jasmine2]</code> Support generator functions as specs. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5166">#&#8203;5166</a>)</li>
<li><code>[jest-jasmine2]</code> Allow <code>spyOn</code> with getters and setters. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5107">#&#8203;5107</a>)</li>
<li><code>[jest-config]</code> Allow configuration objects inside <code>projects</code> array (<a href="https://renovatebot.com/gh/facebook/jest/pull/5176">#&#8203;5176</a>)</li>
<li><code>[expect]</code> Add support to <code>.toHaveProperty</code> matcher to accept the keyPath argument as an array of properties/indices. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5220">#&#8203;5220</a>)</li>
<li><code>[docs]</code> Add documentation for .toHaveProperty matcher to accept the keyPath argument as an array of properties/indices. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5220">#&#8203;5220</a>)</li>
<li><code>[jest-runner]</code> test environments are now passed a new <code>options</code> parameter. Currently this only has the <code>console</code> which is the test console that Jest will expose to tests. (<a href="https://renovatebot.com/gh/facebook/jest/issues/5223">#&#8203;5223</a>)</li>
<li><code>[jest-environment-jsdom]</code> pass the <code>options.console</code> to a custom instance of <code>virtualConsole</code> so jsdom is using the same console as the test. (<a href="https://renovatebot.com/gh/facebook/jest/issues/5223">#&#8203;5223</a>)</li>
</ul>
<h5 id="chore--maintenance-11">Chore &amp; Maintenance</h5>
<ul>
<li><code>[docs]</code> Describe the order of execution of describe and test blocks. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5217">#&#8203;5217</a>, <a href="https://renovatebot.com/gh/facebook/jest/pull/5238">#&#8203;5238</a>)</li>
<li><code>[docs]</code> Add a note on <code>moduleNameMapper</code> ordering. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5249">#&#8203;5249</a>)</li>
</ul>
<hr />
<h3 id="v2204httpsgithubcomfacebookjestblobmasterchangelogmdjest-2204"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2204"><code>v22.0.4</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.0.3…v22.0.4">Compare Source</a></p>
<h5 id="fixes-22">Fixes</h5>
<ul>
<li><code>[jest-cli]</code> New line before quitting watch mode. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5158">#&#8203;5158</a>)</li>
</ul>
<h5 id="features-14">Features</h5>
<ul>
<li><code>[babel-jest]</code> moduleFileExtensions not passed to babel transformer. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5110">#&#8203;5110</a>)</li>
</ul>
<h5 id="chore--maintenance-12">Chore &amp; Maintenance</h5>
<ul>
<li><code>[*]</code> Tweaks to better support Node 4 (<a href="https://renovatebot.com/gh/facebook/jest/pull/5142">#&#8203;5142</a>)</li>
</ul>
<hr />
<h3 id="v2203httpsgithubcomfacebookjestblobmasterchangelogmdjest-2202--2203"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2202--2203"><code>v22.0.3</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.0.2…v22.0.3">Compare Source</a></p>
<h5 id="chore--maintenance-13">Chore &amp; Maintenance</h5>
<ul>
<li><code>[*]</code> Tweaks to better support Node 4 (<a href="https://renovatebot.com/gh/facebook/jest/pull/5134">#&#8203;5134</a>)</li>
</ul>
<hr />
<h3 id="v2202httpsgithubcomfacebookjestblobmasterchangelogmdjest-2202--2203"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2202--2203"><code>v22.0.2</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.0.1…v22.0.2">Compare Source</a></p>
<h5 id="chore--maintenance-14">Chore &amp; Maintenance</h5>
<ul>
<li><code>[*]</code> Tweaks to better support Node 4 (<a href="https://renovatebot.com/gh/facebook/jest/pull/5134">#&#8203;5134</a>)</li>
</ul>
<hr />
<h3 id="v2201httpsgithubcomfacebookjestblobmasterchangelogmdjest-2201"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2201"><code>v22.0.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.0.0…v22.0.1">Compare Source</a></p>
<h5 id="fixes-23">Fixes</h5>
<ul>
<li><code>[jest-runtime]</code> fix error for test files providing coverage. (<a href="https://renovatebot.com/gh/