### PR TITLE
chore(deps): update dependency babel-jest to v23

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
-    "babel-jest": "^21.2.0",
+    "babel-jest": "^23.0.0",
     "babel-preset-env": "^1.6.1",
     "jest": "^21.2.1",
     "jest-cli": "^22.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,7 +39,7 @@
     "@dcos/connections" "0.1.0"
     rxjs "5.4.3"
 
-"@dcos/recordio@^0.1.8":
+"@dcos/recordio@0.1.8":
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/@dcos/recordio/-/recordio-0.1.8.tgz#5fe7cb64215a49b33c4ef9bbef4faf1fcd84273c"
   dependencies:
@@ -159,9 +159,17 @@ arr-diff@^2.0.0:
   dependencies:
     arr-flatten "^1.0.1"
 
-arr-flatten@^1.0.1:
+arr-diff@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
+
+arr-flatten@^1.0.1, arr-flatten@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
+
+arr-union@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
 
 array-equal@^1.0.0:
   version "1.0.0"
@@ -170,6 +178,10 @@ array-equal@^1.0.0:
 array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
+
+array-unique@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
 
 arrify@^1.0.1:
   version "1.0.1"
@@ -186,6 +198,10 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
 assert-plus@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-0.2.0.tgz#d74e1b87e7affc0db8aadb7021f3fe48101ab234"
+
+assign-symbols@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
 
 astral-regex@^1.0.0:
   version "1.0.0"
@@ -212,6 +228,10 @@ async@^2.1.4:
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+
+atob@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.1.tgz#ae2d5a729477f289d60dd7f96a6314a22dd6c22a"
 
 aws-sign2@~0.6.0:
   version "0.6.0"
@@ -406,6 +426,13 @@ babel-jest@^22.4.3:
     babel-plugin-istanbul "^4.1.5"
     babel-preset-jest "^22.4.3"
 
+babel-jest@^23.0.0:
+  version "23.4.2"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-23.4.2.tgz#f276de67798a5d68f2d6e87ff518c2f6e1609877"
+  dependencies:
+    babel-plugin-istanbul "^4.1.6"
+    babel-preset-jest "^23.2.0"
+
 babel-messages@^6.23.0:
   version "6.23.0"
   resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-6.23.0.tgz#f3cdf4703858035b2a2951c6ec5edf6c62f2630e"
@@ -426,6 +453,15 @@ babel-plugin-istanbul@^4.0.0, babel-plugin-istanbul@^4.1.5:
     istanbul-lib-instrument "^1.7.5"
     test-exclude "^4.1.1"
 
+babel-plugin-istanbul@^4.1.6:
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-4.1.6.tgz#36c59b2192efce81c5b378321b74175add1c9a45"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.13.0"
+    find-up "^2.1.0"
+    istanbul-lib-instrument "^1.10.1"
+    test-exclude "^4.2.1"
+
 babel-plugin-jest-hoist@^21.2.0:
   version "21.2.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-21.2.0.tgz#2cef637259bd4b628a6cace039de5fcd14dbb006"
@@ -433,6 +469,10 @@ babel-plugin-jest-hoist@^21.2.0:
 babel-plugin-jest-hoist@^22.4.3:
   version "22.4.3"
   resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-22.4.3.tgz#7d8bcccadc2667f96a0dcc6afe1891875ee6c14a"
+
+babel-plugin-jest-hoist@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-23.2.0.tgz#e61fae05a1ca8801aadee57a6d66b8cefaf44167"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -704,6 +744,13 @@ babel-preset-jest@^22.4.3:
     babel-plugin-jest-hoist "^22.4.3"
     babel-plugin-syntax-object-rest-spread "^6.13.0"
 
+babel-preset-jest@^23.2.0:
+  version "23.2.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz#8ec7a03a138f001a1a8fb1e8113652bf1a55da46"
+  dependencies:
+    babel-plugin-jest-hoist "^23.2.0"
+    babel-plugin-syntax-object-rest-spread "^6.13.0"
+
 babel-register@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-register/-/babel-register-6.26.0.tgz#6ed021173e2fcb486d7acb45c6009a856f647071"
@@ -764,6 +811,18 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
+base@^0.11.1:
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
+  dependencies:
+    cache-base "^1.0.1"
+    class-utils "^0.3.5"
+    component-emitter "^1.2.1"
+    define-property "^1.0.0"
+    isobject "^3.0.1"
+    mixin-deep "^1.2.0"
+    pascalcase "^0.1.1"
+
 bcrypt-pbkdf@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz#63bc5dcb61331b92bc05fd528953c33462a06f8d"
@@ -813,6 +872,21 @@ braces@^1.8.2:
     preserve "^0.2.0"
     repeat-element "^1.1.2"
 
+braces@^2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
+  dependencies:
+    arr-flatten "^1.1.0"
+    array-unique "^0.3.2"
+    extend-shallow "^2.0.1"
+    fill-range "^4.0.0"
+    isobject "^3.0.1"
+    repeat-element "^1.1.2"
+    snapdragon "^0.8.1"
+    snapdragon-node "^2.0.1"
+    split-string "^3.0.2"
+    to-regex "^3.0.1"
+
 browser-process-hrtime@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-0.1.2.tgz#425d68a58d3447f02a04aa894187fce8af8b7b8e"
@@ -843,6 +917,20 @@ buffer-from@^1.0.0:
 builtin-modules@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/builtin-modules/-/builtin-modules-1.1.1.tgz#270f076c5a72c02f5b65a47df94c5fe3a278892f"
+
+cache-base@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/cache-base/-/cache-base-1.0.1.tgz#0a7f46416831c8b662ee36fe4e7c59d76f666ab2"
+  dependencies:
+    collection-visit "^1.0.0"
+    component-emitter "^1.2.1"
+    get-value "^2.0.6"
+    has-value "^1.0.0"
+    isobject "^3.0.1"
+    set-value "^2.0.0"
+    to-object-path "^0.3.0"
+    union-value "^1.0.0"
+    unset-value "^1.0.0"
 
 callsites@^2.0.0:
   version "2.0.0"
@@ -908,6 +996,15 @@ ci-info@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.1.1.tgz#47b44df118c48d2597b56d342e7e25791060171a"
 
+class-utils@^0.3.5:
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/class-utils/-/class-utils-0.3.6.tgz#f93369ae8b9a7ce02fd41faad0ca83033190c463"
+  dependencies:
+    arr-union "^3.1.0"
+    define-property "^0.2.5"
+    isobject "^3.0.0"
+    static-extend "^0.1.1"
+
 cliui@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
@@ -940,6 +1037,13 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
+collection-visit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/collection-visit/-/collection-visit-1.0.0.tgz#4bc0373c164bc3291b4d368c829cf1a80a59dca0"
+  dependencies:
+    map-visit "^1.0.0"
+    object-visit "^1.0.0"
+
 color-convert@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
@@ -964,6 +1068,10 @@ compare-versions@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.2.0.tgz#f36f23aacc539da0e3e0f71af46ce5b953a6ae76"
 
+component-emitter@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -979,6 +1087,10 @@ content-type-parser@^1.0.1:
 convert-source-map@^1.4.0, convert-source-map@^1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.0.tgz#9acd70851c6d5dfdd93d9282e5edf94a03ff46b5"
+
+copy-descriptor@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
 
 core-js@^2.4.0, core-js@^2.5.0:
   version "2.5.1"
@@ -1032,7 +1144,7 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.0.0"
     whatwg-url "^6.4.0"
 
-debug@^2.2.0, debug@^2.6.8:
+debug@^2.2.0, debug@^2.3.3, debug@^2.6.8:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
@@ -1047,6 +1159,10 @@ debug@^3.1.0:
 decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+
+decode-uri-component@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
 
 deep-extend@~0.4.0:
   version "0.4.2"
@@ -1068,6 +1184,25 @@ define-properties@^1.1.2:
   dependencies:
     foreach "^2.0.5"
     object-keys "^1.0.8"
+
+define-property@^0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
+  dependencies:
+    is-descriptor "^0.1.0"
+
+define-property@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-1.0.0.tgz#769ebaaf3f4a63aad3af9e8d304c9bbe79bfb0e6"
+  dependencies:
+    is-descriptor "^1.0.0"
+
+define-property@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/define-property/-/define-property-2.0.2.tgz#d459689e8d654ba77e02a817f8710d702cb16e9d"
+  dependencies:
+    is-descriptor "^1.0.2"
+    isobject "^3.0.1"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -1196,6 +1331,18 @@ expand-brackets@^0.1.4:
   dependencies:
     is-posix-bracket "^0.1.0"
 
+expand-brackets@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622"
+  dependencies:
+    debug "^2.3.3"
+    define-property "^0.2.5"
+    extend-shallow "^2.0.1"
+    posix-character-classes "^0.1.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
+
 expand-range@^1.8.1:
   version "1.8.2"
   resolved "https://registry.yarnpkg.com/expand-range/-/expand-range-1.8.2.tgz#a299effd335fe2721ebae8e257ec79644fc85337"
@@ -1224,6 +1371,19 @@ expect@^22.4.3:
     jest-message-util "^22.4.3"
     jest-regex-util "^22.4.3"
 
+extend-shallow@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-2.0.1.tgz#51af7d614ad9a9f610ea1bafbb989d6b1c56890f"
+  dependencies:
+    is-extendable "^0.1.0"
+
+extend-shallow@^3.0.0, extend-shallow@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend-shallow/-/extend-shallow-3.0.2.tgz#26a71aaf073b39fb2127172746131c2704028db8"
+  dependencies:
+    assign-symbols "^1.0.0"
+    is-extendable "^1.0.1"
+
 extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
@@ -1233,6 +1393,19 @@ extglob@^0.3.1:
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
   dependencies:
     is-extglob "^1.0.0"
+
+extglob@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
+  dependencies:
+    array-unique "^0.3.2"
+    define-property "^1.0.0"
+    expand-brackets "^2.1.4"
+    extend-shallow "^2.0.1"
+    fragment-cache "^0.2.1"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
 
 extsprintf@1.3.0, extsprintf@^1.2.0:
   version "1.3.0"
@@ -1277,6 +1450,15 @@ fill-range@^2.1.0:
     repeat-element "^1.1.2"
     repeat-string "^1.5.2"
 
+fill-range@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-number "^3.0.0"
+    repeat-string "^1.6.1"
+    to-regex-range "^2.1.0"
+
 find-up@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
@@ -1290,7 +1472,7 @@ find-up@^2.0.0, find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
-for-in@^1.0.1:
+for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
 
@@ -1323,6 +1505,12 @@ form-data@~2.3.1:
     asynckit "^0.4.0"
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
+
+fragment-cache@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
+  dependencies:
+    map-cache "^0.2.2"
 
 fs-readdir-recursive@^1.0.0:
   version "1.0.0"
@@ -1380,6 +1568,10 @@ get-caller-file@^1.0.1:
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+
+get-value@^2.0.3, get-value@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/get-value/-/get-value-2.0.6.tgz#dc15ca1c672387ca76bd37ac0a395ba2042a2c28"
 
 getpass@^0.1.1:
   version "0.1.7"
@@ -1472,6 +1664,33 @@ has-flag@^2.0.0:
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
+
+has-value@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/has-value/-/has-value-0.3.1.tgz#7b1f58bada62ca827ec0a2078025654845995e1f"
+  dependencies:
+    get-value "^2.0.3"
+    has-values "^0.1.4"
+    isobject "^2.0.0"
+
+has-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-value/-/has-value-1.0.0.tgz#18b281da585b1c5c51def24c930ed29a0be6b177"
+  dependencies:
+    get-value "^2.0.6"
+    has-values "^1.0.0"
+    isobject "^3.0.0"
+
+has-values@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/has-values/-/has-values-0.1.4.tgz#6d61de95d91dfca9b9a02089ad384bff8f62b771"
+
+has-values@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/has-values/-/has-values-1.0.0.tgz#95b0b63fec2146619a6fe57fe75628d5a39efe4f"
+  dependencies:
+    is-number "^3.0.0"
+    kind-of "^4.0.0"
 
 has@^1.0.1:
   version "1.0.1"
@@ -1582,6 +1801,18 @@ invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
+is-accessor-descriptor@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
+  dependencies:
+    kind-of "^3.0.2"
+
+is-accessor-descriptor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz#169c2f6d3df1f992618072365c9b0ea1f6878656"
+  dependencies:
+    kind-of "^6.0.0"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -1612,9 +1843,37 @@ is-ci@^1.0.10:
   dependencies:
     ci-info "^1.0.0"
 
+is-data-descriptor@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz#0b5ee648388e2c860282e793f1856fec3f301b56"
+  dependencies:
+    kind-of "^3.0.2"
+
+is-data-descriptor@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz#d84876321d0e7add03990406abbbbd36ba9268c7"
+  dependencies:
+    kind-of "^6.0.0"
+
 is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+
+is-descriptor@^0.1.0:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-0.1.6.tgz#366d8240dde487ca51823b1ab9f07a10a78251ca"
+  dependencies:
+    is-accessor-descriptor "^0.1.6"
+    is-data-descriptor "^0.1.4"
+    kind-of "^5.0.0"
+
+is-descriptor@^1.0.0, is-descriptor@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-descriptor/-/is-descriptor-1.0.2.tgz#3b159746a66604b04f8c81524ba365c5f14d86ec"
+  dependencies:
+    is-accessor-descriptor "^1.0.0"
+    is-data-descriptor "^1.0.0"
+    kind-of "^6.0.2"
 
 is-dotfile@^1.0.0:
   version "1.0.3"
@@ -1626,9 +1885,15 @@ is-equal-shallow@^0.1.3:
   dependencies:
     is-primitive "^2.0.0"
 
-is-extendable@^0.1.1:
+is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-0.1.1.tgz#62b110e289a471418e3ec36a617d472e301dfc89"
+
+is-extendable@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-extendable/-/is-extendable-1.0.1.tgz#a7470f9e426733d81bd81e1155264e3a3507cab4"
+  dependencies:
+    is-plain-object "^2.0.4"
 
 is-extglob@^1.0.0:
   version "1.0.0"
@@ -1672,6 +1937,12 @@ is-number@^3.0.0:
   dependencies:
     kind-of "^3.0.2"
 
+is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
+  dependencies:
+    isobject "^3.0.1"
+
 is-posix-bracket@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz#3334dc79774368e92f016e6fbc0a88f5cd6e6bc4"
@@ -1702,6 +1973,10 @@ is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
+is-windows@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
+
 isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -1715,6 +1990,10 @@ isobject@^2.0.0:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-2.1.0.tgz#f065561096a3f1da2ef46272f815c840d87e0c89"
   dependencies:
     isarray "1.0.0"
+
+isobject@^3.0.0, isobject@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -2388,7 +2667,7 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
-kind-of@^3.0.2:
+kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
   dependencies:
@@ -2399,6 +2678,14 @@ kind-of@^4.0.0:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
   dependencies:
     is-buffer "^1.1.5"
+
+kind-of@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
+
+kind-of@^6.0.0, kind-of@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
 
 lazy-cache@^1.0.3:
   version "1.0.4"
@@ -2482,6 +2769,16 @@ makeerror@1.0.x:
   dependencies:
     tmpl "1.0.x"
 
+map-cache@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
+
+map-visit@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
+  dependencies:
+    object-visit "^1.0.0"
+
 mem@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mem/-/mem-1.1.0.tgz#5edd52b485ca1d900fe64895505399a0dfa45f76"
@@ -2516,6 +2813,24 @@ micromatch@^2.1.5, micromatch@^2.3.11:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
+micromatch@^3.1.8:
+  version "3.1.10"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
+  dependencies:
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    braces "^2.3.1"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    extglob "^2.0.4"
+    fragment-cache "^0.2.1"
+    kind-of "^6.0.2"
+    nanomatch "^1.2.9"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.2"
+
 mime-db@~1.30.0:
   version "1.30.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
@@ -2544,6 +2859,13 @@ minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
+mixin-deep@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.1.tgz#a49e7268dce1a0d9698e45326c5626df3543d0fe"
+  dependencies:
+    for-in "^1.0.2"
+    is-extendable "^1.0.1"
+
 "mkdirp@>=0.5 0", mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
@@ -2557,6 +2879,22 @@ ms@2.0.0:
 nan@^2.3.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
+
+nanomatch@^1.2.9:
+  version "1.2.13"
+  resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
+  dependencies:
+    arr-diff "^4.0.0"
+    array-unique "^0.3.2"
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    fragment-cache "^0.2.1"
+    is-windows "^1.0.2"
+    kind-of "^6.0.2"
+    object.pick "^1.3.0"
+    regex-not "^1.0.0"
+    snapdragon "^0.8.1"
+    to-regex "^3.0.1"
 
 natural-compare@^1.4.0:
   version "1.4.0"
@@ -2643,9 +2981,23 @@ object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
+object-copy@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/object-copy/-/object-copy-0.1.0.tgz#7e7d858b781bd7c991a41ba975ed3812754e998c"
+  dependencies:
+    copy-descriptor "^0.1.0"
+    define-property "^0.2.5"
+    kind-of "^3.0.3"
+
 object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
+
+object-visit@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/object-visit/-/object-visit-1.0.1.tgz#f79c4493af0c5377b59fe39d395e41042dd045bb"
+  dependencies:
+    isobject "^3.0.0"
 
 object.getownpropertydescriptors@^2.0.3:
   version "2.0.3"
@@ -2660,6 +3012,12 @@ object.omit@^2.0.0:
   dependencies:
     for-own "^0.1.4"
     is-extendable "^0.1.1"
+
+object.pick@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/object.pick/-/object.pick-1.3.0.tgz#87a10ac4c1694bd2e1cbf53591a66141fb5dd747"
+  dependencies:
+    isobject "^3.0.1"
 
 once@^1.3.0, once@^1.3.3, once@^1.4.0:
   version "1.4.0"
@@ -2757,6 +3115,10 @@ parse5@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
 
+pascalcase@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
+
 path-exists@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-2.1.0.tgz#0feb6c64f0fc518d9a754dd5efb62c7022761f4b"
@@ -2828,6 +3190,10 @@ pkg-dir@^2.0.0:
 pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
+
+posix-character-classes@^0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -2982,6 +3348,13 @@ regex-cache@^0.4.2:
   dependencies:
     is-equal-shallow "^0.1.3"
 
+regex-not@^1.0.0, regex-not@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/regex-not/-/regex-not-1.0.2.tgz#1f4ece27e00b0b65e0247a6810e6a85d83a5752c"
+  dependencies:
+    extend-shallow "^3.0.2"
+    safe-regex "^1.1.0"
+
 regexpu-core@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/regexpu-core/-/regexpu-core-2.0.0.tgz#49d038837b8dcf8bfa5b9a42139938e6ea2ae240"
@@ -3008,7 +3381,7 @@ repeat-element@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.2.tgz#ef089a178d1483baae4d93eb98b4f9e4e11d990a"
 
-repeat-string@^1.5.2:
+repeat-string@^1.5.2, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
 
@@ -3104,9 +3477,17 @@ resolve-from@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
 
+resolve-url@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
+
 resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
+
+ret@~0.1.10:
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
 
 right-align@^0.1.1:
   version "0.1.3"
@@ -3129,6 +3510,12 @@ rxjs@5.4.3:
 safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
+
+safe-regex@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
+  dependencies:
+    ret "~0.1.10"
 
 sane@^2.0.0:
   version "2.2.0"
@@ -3160,6 +3547,24 @@ set-immediate-shim@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
 
+set-value@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-0.4.3.tgz#7db08f9d3d22dc7f78e53af3c3bf4666ecdfccf1"
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.1"
+    to-object-path "^0.3.0"
+
+set-value@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/set-value/-/set-value-2.0.0.tgz#71ae4a88f0feefbbf52d1ea604f3fb315ebb6274"
+  dependencies:
+    extend-shallow "^2.0.1"
+    is-extendable "^0.1.1"
+    is-plain-object "^2.0.3"
+    split-string "^3.0.1"
+
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
@@ -3182,6 +3587,33 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
 
+snapdragon-node@^2.0.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
+  dependencies:
+    define-property "^1.0.0"
+    isobject "^3.0.0"
+    snapdragon-util "^3.0.1"
+
+snapdragon-util@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/snapdragon-util/-/snapdragon-util-3.0.1.tgz#f956479486f2acd79700693f6f7b805e45ab56e2"
+  dependencies:
+    kind-of "^3.2.0"
+
+snapdragon@^0.8.1:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/snapdragon/-/snapdragon-0.8.2.tgz#64922e7c565b0e14204ba1aa7d6964278d25182d"
+  dependencies:
+    base "^0.11.1"
+    debug "^2.2.0"
+    define-property "^0.2.5"
+    extend-shallow "^2.0.1"
+    map-cache "^0.2.2"
+    source-map "^0.5.6"
+    source-map-resolve "^0.5.0"
+    use "^3.1.0"
+
 sntp@1.x.x:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/sntp/-/sntp-1.0.9.tgz#6541184cc90aeea6c6e7b35e2659082443c66198"
@@ -3193,6 +3625,16 @@ sntp@2.x.x:
   resolved "https://registry.yarnpkg.com/sntp/-/sntp-2.0.2.tgz#5064110f0af85f7cfdb7d6b67a40028ce52b4b2b"
   dependencies:
     hoek "4.x.x"
+
+source-map-resolve@^0.5.0:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/source-map-resolve/-/source-map-resolve-0.5.2.tgz#72e2cc34095543e43b2c62b2c4c10d4a9054f259"
+  dependencies:
+    atob "^2.1.1"
+    decode-uri-component "^0.2.0"
+    resolve-url "^0.2.1"
+    source-map-url "^0.4.0"
+    urix "^0.1.0"
 
 source-map-support@^0.4.15:
   version "0.4.18"
@@ -3206,6 +3648,10 @@ source-map-support@^0.5.0:
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
+
+source-map-url@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
 
 source-map@^0.4.4:
   version "0.4.4"
@@ -3235,6 +3681,12 @@ spdx-license-ids@^1.0.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz#c9df7a3424594ade6bd11900d596696dc06bac57"
 
+split-string@^3.0.1, split-string@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
+  dependencies:
+    extend-shallow "^3.0.0"
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -3256,6 +3708,13 @@ sshpk@^1.7.0:
 stack-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
+
+static-extend@^0.1.1:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/static-extend/-/static-extend-0.1.2.tgz#60809c39cbff55337226fd5e0b520f341f1fb5c6"
+  dependencies:
+    define-property "^0.2.5"
+    object-copy "^0.1.0"
 
 stealthy-require@^1.1.0:
   version "1.1.1"
@@ -3378,6 +3837,16 @@ test-exclude@^4.1.1:
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
 
+test-exclude@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.2.1.tgz#dfa222f03480bca69207ca728b37d74b45f724fa"
+  dependencies:
+    arrify "^1.0.1"
+    micromatch "^3.1.8"
+    object-assign "^4.1.0"
+    read-pkg-up "^1.0.1"
+    require-main-filename "^1.0.1"
+
 throat@^4.0.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-4.1.0.tgz#89037cbc92c56ab18926e6ba4cbb200e15672a6a"
@@ -3389,6 +3858,28 @@ tmpl@1.0.x:
 to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+
+to-object-path@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af"
+  dependencies:
+    kind-of "^3.0.2"
+
+to-regex-range@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-2.1.1.tgz#7c80c17b9dfebe599e27367e0d4dd5590141db38"
+  dependencies:
+    is-number "^3.0.0"
+    repeat-string "^1.6.1"
+
+to-regex@^3.0.1, to-regex@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/to-regex/-/to-regex-3.0.2.tgz#13cfdd9b336552f30b51f33a8ae1b42a7a7599ce"
+  dependencies:
+    define-property "^2.0.2"
+    extend-shallow "^3.0.2"
+    regex-not "^1.0.2"
+    safe-regex "^1.1.0"
 
 tough-cookie@>=2.3.3, tough-cookie@^2.3.2, tough-cookie@^2.3.3, tough-cookie@~2.3.0, tough-cookie@~2.3.3:
   version "2.3.4"
@@ -3442,6 +3933,30 @@ uglify-to-browserify@~1.0.0:
 uid-number@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
+
+union-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/union-value/-/union-value-1.0.0.tgz#5c71c34cb5bad5dcebe3ea0cd08207ba5aa1aea4"
+  dependencies:
+    arr-union "^3.1.0"
+    get-value "^2.0.6"
+    is-extendable "^0.1.1"
+    set-value "^0.4.3"
+
+unset-value@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unset-value/-/unset-value-1.0.0.tgz#8376873f7d2335179ffb1e6fc3a8ed0dfc8ab559"
+  dependencies:
+    has-value "^0.3.1"
+    isobject "^3.0.0"
+
+urix@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
+
+use@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
 
 user-home@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
<p>This Pull Request updates devDependency <a href="https://renovatebot.com/gh/facebook/jest">babel-jest</a> from <code>^21.2.0</code> to <code>^23.0.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v2342httpsgithubcomfacebookjestblobmasterchangelogmd82032342"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2342"><code>v23.4.2</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v23.4.0…v23.4.2">Compare Source</a></p>
<h5 id="performance">Performance</h5>
<ul>
<li><code>[jest-changed-files]</code> limit git and hg commands to specified roots (<a href="https://renovatebot.com/gh/facebook/jest/pull/6732">#&#8203;6732</a>)</li>
</ul>
<h5 id="fixes">Fixes</h5>
<ul>
<li><code>[jest-circus]</code> Fix retryTimes so errors are reset before re-running (<a href="https://renovatebot.com/gh/facebook/jest/pull/6762">#&#8203;6762</a>)</li>
<li><code>[docs]</code> Update <code>expect.objectContaining()</code> description (<a href="https://renovatebot.com/gh/facebook/jest/pull/6754">#&#8203;6754</a>)</li>
<li><code>[babel-jest]</code> Make <code>getCacheKey()</code> take into account <code>createTransformer</code> options (<a href="https://renovatebot.com/gh/facebook/jest/pull/6699">#&#8203;6699</a>)</li>
<li><code>[jest-jasmine2]</code> Use prettier through <code>require</code> instead of <code>localRequire</code>. Fixes <code>matchInlineSnapshot</code> where prettier dependencies like <code>path</code> and <code>fs</code> are mocked with <code>jest.mock</code>. (<a href="https://renovatebot.com/gh/facebook/jest/pull/6776">#&#8203;6776</a>)</li>
<li><code>[docs]</code> Fix contributors link (<a href="https://renovatebot.com/gh/facebook/jest/pull/6711">#&#8203;6711</a>)</li>
<li><code>[website]</code> Fix website versions page to link to correct language (<a href="https://renovatebot.com/gh/facebook/jest/pull/6734">#&#8203;6734</a>)</li>
<li><code>[expect]</code> Update <code>toContain</code> suggestion to contain equal message (<a href="https://renovatebot.com/gh/facebook/jest/pull/6810">#&#8203;6792</a>)</li>
</ul>
<hr />
<h3 id="v2340httpsgithubcomfacebookjestblobmasterchangelogmd82032340"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2340"><code>v23.4.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v23.2.0…v23.4.0">Compare Source</a></p>
<h5 id="features">Features</h5>
<ul>
<li><code>[jest-haste-map]</code> Add <code>computeDependencies</code> flag to avoid opening files if not needed (<a href="https://renovatebot.com/gh/facebook/jest/pull/6667">#&#8203;6667</a>)</li>
<li><code>[jest-runtime]</code> Support <code>require.resolve.paths</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6471">#&#8203;6471</a>)</li>
<li><code>[jest-runtime]</code> Support <code>paths</code> option for <code>require.resolve</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6471">#&#8203;6471</a>)</li>
</ul>
<h5 id="fixes-1">Fixes</h5>
<ul>
<li><code>[jest-runner]</code> Force parallel runs for watch mode, to avoid TTY freeze (<a href="https://renovatebot.com/gh/facebook/jest/pull/6647">#&#8203;6647</a>)</li>
<li><code>[jest-cli]</code> properly reprint resolver errors in watch mode (<a href="https://renovatebot.com/gh/facebook/jest/pull/6407">#&#8203;6407</a>)</li>
<li><code>[jest-cli]</code> Write configuration to stdout when the option was explicitly passed to Jest (<a href="https://renovatebot.com/gh/facebook/jest/pull/6447">#&#8203;6447</a>)</li>
<li><code>[jest-cli]</code> Fix regression on non-matching suites (<a href="https://renovatebot.com/gh/facebook/jest/pull/6657">6657</a>)</li>
<li><code>[jest-runtime]</code> Roll back <code>micromatch</code> version to prevent regression when matching files (<a href="https://renovatebot.com/gh/facebook/jest/pull/6661">#&#8203;6661</a>)</li>
</ul>
<hr />
<h3 id="v2320httpsgithubcomfacebookjestblobmasterchangelogmd82032320"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2320"><code>v23.2.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v23.0.1…v23.2.0">Compare Source</a></p>
<h5 id="features-1">Features</h5>
<ul>
<li><code>[jest-each]</code> Add support for keyPaths in test titles (<a href="https://renovatebot.com/gh/facebook/jest/pull/6457">#&#8203;6457</a>)</li>
<li><code>[jest-cli]</code> Add <code>jest --init</code> option that generates a basic configuration file with a short description for each option (<a href="https://renovatebot.com/gh/facebook/jest/pull/6442">#&#8203;6442</a>)</li>
<li><code>[jest.retryTimes]</code> Add <code>jest.retryTimes()</code> option that allows failed tests to be retried n-times when using jest-circus. (<a href="https://renovatebot.com/gh/facebook/jest/pull/6498">#&#8203;6498</a>)</li>
</ul>
<h5 id="fixes-2">Fixes</h5>
<ul>
<li><code>[docs]</code> Fixed error in documentation for expect.not.arrayContaining(array). (<a href="https://renovatebot.com/gh/facebook/jest/pull/6491">#&#8203;6491</a>)</li>
<li><code>[jest-cli]</code> Add check to make sure one or more tests have run before notifying when using <code>--notify</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6495">#&#8203;6495</a>)</li>
<li><code>[jest-cli]</code> Pass <code>globalConfig</code> as a parameter to <code>globalSetup</code> and <code>globalTeardown</code> functions (<a href="https://renovatebot.com/gh/facebook/jest/pull/6486">#&#8203;6486</a>)</li>
<li><code>[jest-config]</code> Add missing options to the <code>defaults</code> object (<a href="https://renovatebot.com/gh/facebook/jest/pull/6428">#&#8203;6428</a>)</li>
<li><code>[expect]</code> Using symbolic property names in arrays no longer causes the <code>toEqual</code> matcher to fail (<a href="https://renovatebot.com/gh/facebook/jest/pull/6391">#&#8203;6391</a>)</li>
<li><code>[expect]</code> <code>toEqual</code> no longer tries to compare non-enumerable symbolic properties, to be consistent with non-symbolic properties. (<a href="https://renovatebot.com/gh/facebook/jest/pull/6398">#&#8203;6398</a>)</li>
<li><code>[jest-util]</code> <code>console.timeEnd</code> now properly log elapsed time in milliseconds. (<a href="https://renovatebot.com/gh/facebook/jest/pull/6456">#&#8203;6456</a>)</li>
<li><code>[jest-mock]</code> Fix <code>MockNativeMethods</code> access in react-native <code>jest.mock()</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6505">#&#8203;6505</a>)</li>
</ul>
<h5 id="chore--maintenance">Chore &amp; Maintenance</h5>
<ul>
<li><code>[docs]</code> Add jest-each docs for 1 dimensional arrays (<a href="https://renovatebot.com/gh/facebook/jest/pull/6444/files">#&#8203;6444</a>)</li>
</ul>
<hr />
<h3 id="v2301httpsgithubcomfacebookjestblobmasterchangelogmd82032301"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2301"><code>v23.0.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v23.0.0…v23.0.1">Compare Source</a></p>
<h5 id="chore--maintenance-1">Chore &amp; Maintenance</h5>
<ul>
<li><code>[jest-jasemine2]</code> Add dependency on jest-each (<a href="https://renovatebot.com/gh/facebook/jest/pull/6308">#&#8203;6308</a>)</li>
<li><code>[jest-each]</code> Move jest-each into core Jest (<a href="https://renovatebot.com/gh/facebook/jest/pull/6278">#&#8203;6278</a>)</li>
<li><code>[examples]</code> Update typescript example to using ts-jest (<a href="https://renovatebot.com/gh/facebook/jest/pull/6260">#&#8203;6260</a>)</li>
</ul>
<h5 id="fixes-3">Fixes</h5>
<ul>
<li><code>[pretty-format]</code> Serialize inverse asymmetric matchers correctly (<a href="https://renovatebot.com/gh/facebook/jest/pull/6272">#&#8203;6272</a>)</li>
</ul>
<hr />
<h3 id="v2300httpsgithubcomfacebookjestblobmasterchangelogmd82032300"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2300"><code>v23.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.4.4…v23.0.0">Compare Source</a></p>
<h5 id="features-2">Features</h5>
<ul>
<li><code>[expect]</code> Expose <code>getObjectSubset</code>, <code>iterableEquality</code>, and <code>subsetEquality</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6210">#&#8203;6210</a>)</li>
<li><code>[jest-snapshot]</code> Add snapshot property matchers (<a href="https://renovatebot.com/gh/facebook/jest/pull/6210">#&#8203;6210</a>)</li>
<li><code>[jest-config]</code> Support jest-preset.js files within Node modules (<a href="https://renovatebot.com/gh/facebook/jest/pull/6185">#&#8203;6185</a>)</li>
<li><code>[jest-cli]</code> Add <code>--detectOpenHandles</code> flag which enables Jest to potentially track down handles keeping it open after tests are complete. (<a href="https://renovatebot.com/gh/facebook/jest/pull/6130">#&#8203;6130</a>)</li>
<li><code>[jest-jasmine2]</code> Add data driven testing based on <code>jest-each</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6102">#&#8203;6102</a>)</li>
<li><code>[jest-matcher-utils]</code> Change "suggest to equal" message to be more advisory (<a href="https://renovatebot.com/gh/facebook/jest/issues/6103">#&#8203;6103</a>)</li>
<li><code>[jest-message-util]</code> Don't ignore messages with <code>vendor</code> anymore (<a href="https://renovatebot.com/gh/facebook/jest/pull/6117">#&#8203;6117</a>)</li>
<li><code>[jest-validate]</code> Get rid of <code>jest-config</code> dependency (<a href="https://renovatebot.com/gh/facebook/jest/pull/6067">#&#8203;6067</a>)</li>
<li><code>[jest-validate]</code> Adds option to inject <code>deprecationEntries</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6067">#&#8203;6067</a>)</li>
<li><code>[jest-snapshot]</code> [<strong>BREAKING</strong>] Concatenate name of test, optional snapshot name and count (<a href="https://renovatebot.com/gh/facebook/jest/pull/6015">#&#8203;6015</a>)</li>
<li><code>[jest-runtime]</code> Allow for transform plugins to skip the definition process method if createTransformer method was defined. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5999">#&#8203;5999</a>)</li>
<li><code>[expect]</code> Add stack trace for async errors (<a href="https://renovatebot.com/gh/facebook/jest/pull/6008">#&#8203;6008</a>)</li>
<li><code>[jest-jasmine2]</code> Add stack trace for timeouts (<a href="https://renovatebot.com/gh/facebook/jest/pull/6008">#&#8203;6008</a>)</li>
<li><code>[jest-jasmine2]</code> Add stack trace for thrown non-<code>Error</code>s (<a href="https://renovatebot.com/gh/facebook/jest/pull/6008">#&#8203;6008</a>)</li>
<li><code>[jest-runtime]</code> Prevent modules from marking themselves as their own parent (<a href="https://renovatebot.com/gh/facebook/jest/issues/5235">#&#8203;5235</a>)</li>
<li><code>[jest-mock]</code> Add support for auto-mocking generator functions (<a href="https://renovatebot.com/gh/facebook/jest/pull/5983">#&#8203;5983</a>)</li>
<li><code>[expect]</code> Add support for async matchers  (<a href="https://renovatebot.com/gh/facebook/jest/pull/5919">#&#8203;5919</a>)</li>
<li><code>[expect]</code> Suggest toContainEqual (<a href="https://renovatebot.com/gh/facebook/jest/pull/5953">#&#8203;5948</a>)</li>
<li><code>[jest-config]</code> Export Jest's default options (<a href="https://renovatebot.com/gh/facebook/jest/pull/5948">#&#8203;5948</a>)</li>
<li><code>[jest-editor-support]</code> Move <code>coverage</code> to <code>ProjectWorkspace.collectCoverage</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5929">#&#8203;5929</a>)</li>
<li><code>[jest-editor-support]</code> Add <code>coverage</code> option to runner (<a href="https://renovatebot.com/gh/facebook/jest/pull/5836">#&#8203;5836</a>)</li>
<li><code>[jest-haste-map]</code> Support extracting dynamic <code>import</code>s (<a href="https://renovatebot.com/gh/facebook/jest/pull/5883">#&#8203;5883</a>)</li>
<li><code>[expect]</code> Improve output format for mismatchedArgs in mock/spy calls. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5846">#&#8203;5846</a>)</li>
<li><code>[jest-cli]</code> Add support for using <code>--coverage</code> in combination with watch mode, <code>--onlyChanged</code>, <code>--findRelatedTests</code> and more (<a href="https://renovatebot.com/gh/facebook/jest/pull/5601">#&#8203;5601</a>)</li>
<li><code>[jest-jasmine2]</code> [<strong>BREAKING</strong>] Adds error throwing and descriptive errors to <code>it</code>/ <code>test</code> for invalid arguments. <code>[jest-circus]</code> Adds error throwing and descriptive errors to <code>it</code>/ <code>test</code> for invalid arguments (<a href="https://renovatebot.com/gh/facebook/jest/pull/5558">#&#8203;5558</a>)</li>
<li><code>[jest-matcher-utils]</code> Add <code>isNot</code> option to <code>matcherHint</code> function (<a href="https://renovatebot.com/gh/facebook/jest/pull/5512">#&#8203;5512</a>)</li>
<li><code>[jest-config]</code> Add <code>&lt;rootDir&gt;</code> to runtime files not found error report (<a href="https://renovatebot.com/gh/facebook/jest/pull/5693">#&#8203;5693</a>)</li>
<li><code>[expect]</code> Make toThrow matcher pass only if Error object is returned from promises (<a href="https://renovatebot.com/gh/facebook/jest/pull/5670">#&#8203;5670</a>)</li>
<li><code>[expect]</code> Add isError to utils (<a href="https://renovatebot.com/gh/facebook/jest/pull/5670">#&#8203;5670</a>)</li>
<li><code>[expect]</code> Add inverse matchers (<code>expect.not.arrayContaining</code>, etc., <a href="https://renovatebot.com/gh/facebook/jest/pull/5517">#&#8203;5517</a>)</li>
<li><code>[expect]</code> <code>expect.extend</code> now also extends asymmetric matchers (<a href="https://renovatebot.com/gh/facebook/jest/pull/5503">#&#8203;5503</a>)</li>
<li><code>[jest-mock]</code> Update <code>spyOnProperty</code> to support spying on the prototype chain (<a href="https://renovatebot.com/gh/facebook/jest/pull/5753">#&#8203;5753</a>)</li>
<li><code>[jest-mock]</code> Add tracking of return values in the <code>mock</code> property (<a href="https://renovatebot.com/gh/facebook/jest/pull/5752">#&#8203;5752</a>)</li>
<li><code>[jest-mock]</code> Add tracking of thrown errors in the <code>mock</code> property (<a href="https://renovatebot.com/gh/facebook/jest/pull/5764">#&#8203;5764</a>)</li>
<li><code>[expect]</code>Add nthCalledWith spy matcher (<a href="https://renovatebot.com/gh/facebook/jest/pull/5605">#&#8203;5605</a>)</li>
<li><code>[jest-cli]</code> Add <code>isSerial</code> property that runners can expose to specify that they can not run in parallel (<a href="https://renovatebot.com/gh/facebook/jest/pull/5706">#&#8203;5706</a>)</li>
<li><code>[expect]</code> Add <code>.toBeCalledTimes</code> and <code>toHaveBeenNthCalledWith</code> aliases (<a href="https://renovatebot.com/gh/facebook/jest/pull/5826">#&#8203;5826</a>)</li>
<li><code>[jest-cli]</code> Interactive Snapshot Mode improvements (<a href="https://renovatebot.com/gh/facebook/jest/pull/5864">#&#8203;5864</a>)</li>
<li><code>[jest-editor-support]</code> Add <code>no-color</code> option to runner (<a href="https://renovatebot.com/gh/facebook/jest/pull/5909">#&#8203;5909</a>)</li>
<li><code>[jest-jasmine2]</code> Pretty-print non-Error object errors (<a href="https://renovatebot.com/gh/facebook/jest/pull/5980">#&#8203;5980</a>)</li>
<li><code>[jest-message-util]</code> Include column in stack frames (<a href="https://renovatebot.com/gh/facebook/jest/pull/5889">#&#8203;5889</a>)</li>
<li><code>[expect]</code> Introduce toStrictEqual (<a href="https://renovatebot.com/gh/facebook/jest/pull/6032">#&#8203;6032</a>)</li>
<li><code>[expect]</code> Add return matchers (<a href="https://renovatebot.com/gh/facebook/jest/pull/5879">#&#8203;5879</a>)</li>
<li><code>[jest-cli]</code> Improve snapshot summaries (<a href="https://renovatebot.com/gh/facebook/jest/pull/6181">#&#8203;6181</a>)</li>
<li><code>[expect]</code> Include custom mock names in error messages (<a href="https://renovatebot.com/gh/facebook/jest/pull/6199">#&#8203;6199</a>)</li>
<li><code>[jest-diff]</code> Support returning diff from oneline strings (<a href="https://renovatebot.com/gh/facebook/jest/pull/6221">#&#8203;6221</a>)</li>
<li><code>[expect]</code> Improve return matchers (<a href="https://renovatebot.com/gh/facebook/jest/pull/6172">#&#8203;6172</a>)</li>
<li><code>[jest-cli]</code> Overhaul watch plugin hooks names (<a href="https://renovatebot.com/gh/facebook/jest/pull/6249">#&#8203;6249</a>)</li>
<li><code>[jest-mock]</code> Include tracked call results in serialized mock (<a href="https://renovatebot.com/gh/facebook/jest/pull/6244">#&#8203;6244</a>)</li>
</ul>
<h5 id="fixes-4">Fixes</h5>
<ul>
<li><code>[jest-cli]</code> Fix stdin encoding to utf8 for watch plugins. (<a href="https://renovatebot.com/gh/facebook/jest/issues/6253">#&#8203;6253</a>)</li>
<li><code>[expect]</code> Better detection of DOM Nodes for equality (<a href="https://renovatebot.com/gh/facebook/jest/pull/6246">#&#8203;6246</a>)</li>
<li><code>[jest-cli]</code> Fix misleading action description for F key when in "only failed tests" mode. (<a href="https://renovatebot.com/gh/facebook/jest/issues/6167">#&#8203;6167</a>)</li>
<li><code>[jest-worker]</code> Stick calls to workers before processing them (<a href="https://renovatebot.com/gh/facebook/jest/pull/6073">#&#8203;6073</a>)</li>
<li><code>[babel-plugin-jest-hoist]</code> Allow using <code>console</code> global variable (<a href="https://renovatebot.com/gh/facebook/jest/pull/6075">#&#8203;6075</a>)</li>
<li><code>[jest-jasmine2]</code> Always remove node core message from assert stack traces (<a href="https://renovatebot.com/gh/facebook/jest/pull/6055">#&#8203;6055</a>)</li>
<li><code>[expect]</code> Add stack trace when <code>expect.assertions</code> and <code>expect.hasAssertions</code> causes test failures. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5997">#&#8203;5997</a>)</li>
<li><code>[jest-runtime]</code> Throw a more useful error when trying to require modules after the test environment is torn down (<a href="https://renovatebot.com/gh/facebook/jest/pull/5888">#&#8203;5888</a>)</li>
<li><code>[jest-mock]</code> [<strong>BREAKING</strong>] Replace timestamps with <code>invocationCallOrder</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5867">#&#8203;5867</a>)</li>
<li><code>[jest-jasmine2]</code> Install <code>sourcemap-support</code> into normal runtime to catch runtime errors (<a href="https://renovatebot.com/gh/facebook/jest/pull/5945">#&#8203;5945</a>)</li>
<li><code>[jest-jasmine2]</code> Added assertion error handling inside <code>afterAll hook</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5884">#&#8203;5884</a>)</li>
<li><code>[jest-cli]</code> Remove the notifier actions in case of failure when not in watch mode. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5861">#&#8203;5861</a>)</li>
<li><code>[jest-mock]</code> Extend .toHaveBeenCalled return message with outcome (<a href="https://renovatebot.com/gh/facebook/jest/pull/5951">#&#8203;5951</a>)</li>
<li><code>[jest-runner]</code> Assign <code>process.env.JEST_WORKER_ID="1"</code> when in runInBand mode (<a href="https://renovatebot.com/gh/facebook/jest/pull/5860">#&#8203;5860</a>)</li>
<li><code>[jest-cli]</code> Add descriptive error message when trying to use <code>globalSetup</code>/<code>globalTeardown</code> file that doesn't export a function. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5835">#&#8203;5835</a>)</li>
<li><code>[expect]</code> Do not rely on <code>instanceof RegExp</code>, since it will not work for RegExps created inside of a different VM (<a href="https://renovatebot.com/gh/facebook/jest/pull/5729">#&#8203;5729</a>)</li>
<li><code>[jest-resolve]</code> Update node module resolution algorithm to correctly handle symlinked paths (<a href="https://renovatebot.com/gh/facebook/jest/pull/5085">#&#8203;5085</a>)</li>
<li><code>[jest-editor-support]</code> Update <code>Settings</code> to use spawn in shell option (<a href="https://renovatebot.com/gh/facebook/jest/pull/5658">#&#8203;5658</a>)</li>
<li><code>[jest-cli]</code> Improve the error message when 2 projects resolve to the same config (<a href="https://renovatebot.com/gh/facebook/jest/pull/5674">#&#8203;5674</a>)</li>
<li><code>[jest-runtime]</code> remove retainLines from coverage instrumentation (<a href="https://renovatebot.com/gh/facebook/jest/pull/5692">#&#8203;5692</a>)</li>
<li><code>[jest-cli]</code> Fix update snapshot issue when using watchAll (<a href="https://renovatebot.com/gh/facebook/jest/pull/5696">#&#8203;5696</a>)</li>
<li><code>[expect]</code> Fix rejects.not matcher (<a href="https://renovatebot.com/gh/facebook/jest/pull/5670">#&#8203;5670</a>)</li>
<li><code>[jest-runtime]</code> Prevent Babel warnings on large files (<a href="https://renovatebot.com/gh/facebook/jest/pull/5702">#&#8203;5702</a>)</li>
<li><code>[jest-mock]</code> Prevent <code>mockRejectedValue</code> from causing unhandled rejection (<a href="https://renovatebot.com/gh/facebook/jest/pull/5720">#&#8203;5720</a>)</li>
<li><code>[pretty-format]</code> Handle React fragments better (<a href="https://renovatebot.com/gh/facebook/jest/pull/5816">#&#8203;5816</a>)</li>
<li><code>[pretty-format]</code> Handle formatting of <code>React.forwardRef</code> and <code>Context</code> components (<a href="https://renovatebot.com/gh/facebook/jest/pull/6093">#&#8203;6093</a>)</li>
<li><code>[jest-cli]</code> Switch collectCoverageFrom back to a string (<a href="https://renovatebot.com/gh/facebook/jest/pull/5914">#&#8203;5914</a>)</li>
<li><code>[jest-regex-util]</code> Fix handling regex symbols in tests path on Windows (<a href="https://renovatebot.com/gh/facebook/jest/pull/5941">#&#8203;5941</a>)</li>
<li><code>[jest-util]</code> Fix handling of NaN/Infinity in mock timer delay (<a href="https://renovatebot.com/gh/facebook/jest/pull/5966">#&#8203;5966</a>)</li>
<li><code>[jest-resolve]</code> Generalise test for package main entries equivalent to ".". (<a href="https://renovatebot.com/gh/facebook/jest/pull/5968">#&#8203;5968</a>)</li>
<li><code>[jest-config]</code> Ensure that custom resolvers are used when resolving the configuration (<a href="https://renovatebot.com/gh/facebook/jest/pull/5976">#&#8203;5976</a>)</li>
<li><code>[website]</code> Fix website docs (<a href="https://renovatebot.com/gh/facebook/jest/pull/5853">#&#8203;5853</a>)</li>
<li><code>[expect]</code> Fix isEqual Set and Map to compare object values and keys regardless of order (<a href="https://renovatebot.com/gh/facebook/jest/pull/6150">#&#8203;6150</a>)</li>
<li><code>[pretty-format]</code> [<strong>BREAKING</strong>] Remove undefined props from React elements (<a href="https://renovatebot.com/gh/facebook/jest/pull/6162">#&#8203;6162</a>)</li>
<li><code>[jest-haste-map]</code> Properly resolve mocked node modules without package.json defined (<a href="https://renovatebot.com/gh/facebook/jest/pull/6232">#&#8203;6232</a>)</li>
</ul>
<h5 id="chore--maintenance-2">Chore &amp; Maintenance</h5>
<ul>
<li><code>[jest-runner]</code> Move sourcemap installation from <code>jest-jasmine2</code> to <code>jest-runner</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6176">#&#8203;6176</a>)</li>
<li><code>[jest-cli]</code> Use yargs's built-in <code>version</code> instead of rolling our own (<a href="https://renovatebot.com/gh/facebook/jest/pull/6215">#&#8203;6215</a>)</li>
<li><code>[docs]</code> Add explanation on how to mock methods not implemented in JSDOM</li>
<li><code>[jest-jasmine2]</code> Simplify <code>Env.execute</code> and TreeProcessor to setup and clean resources for the top suite the same way as for all of the children suites (<a href="https://renovatebot.com/gh/facebook/jest/pull/5885">#&#8203;5885</a>)</li>
<li><code>[babel-jest]</code> [<strong>BREAKING</strong>] Always return object from transformer (<a href="https://renovatebot.com/gh/facebook/jest/pull/5991">#&#8203;5991</a>)</li>
<li><code>[*]</code> Run Prettier on compiled output (<a href="https://renovatebot.com/gh/facebook/jest/pull/3497">#&#8203;5858</a>)</li>
<li><code>[jest-cli]</code> Add fileChange hook for plugins (<a href="https://renovatebot.com/gh/facebook/jest/pull/5708">#&#8203;5708</a>)</li>
<li><code>[docs]</code> Add docs on using <code>jest.mock(...)</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5648">#&#8203;5648</a>)</li>
<li><code>[docs]</code> Mention Jest Puppeteer Preset (<a href="https://renovatebot.com/gh/facebook/jest/pull/5722">#&#8203;5722</a>)</li>
<li><code>[docs]</code> Add jest-community section to website (<a href="https://renovatebot.com/gh/facebook/jest/pull/5675">#&#8203;5675</a>)</li>
<li><code>[docs]</code> Add versioned docs for v22.4 (<a href="https://renovatebot.com/gh/facebook/jest/pull/5733">#&#8203;5733</a>)</li>
<li><code>[docs]</code> Improve Snapshot Testing Guide (<a href="https://renovatebot.com/gh/facebook/jest/issues/5812">#&#8203;5812</a>)</li>
<li><code>[jest-runtime]</code> [<strong>BREAKING</strong>] Remove <code>jest.genMockFn</code> and <code>jest.genMockFunction</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/6173">#&#8203;6173</a>)</li>
<li><code>[jest-message-util]</code> Avoid adding unnecessary indent to blank lines in stack traces (<a href="https://renovatebot.com/gh/facebook/jest/pull/6211">#&#8203;6211</a>)</li>
</ul>
<hr />
<h3 id="v2244httpsgithubcomfacebookjestcompare6851d8bc9d67e83fb1bb0199d28ef84565938225v2244"><a href="https://renovatebot.com/gh/facebook/jest/compare/6851d8bc9d67e83fb1bb0199d28ef84565938225…v22.4.4"><code>v22.4.4</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/6851d8bc9d67e83fb1bb0199d28ef84565938225…v22.4.4">Compare Source</a></p>
<hr />
<h3 id="v2243httpsgithubcomfacebookjestcomparev22416851d8bc9d67e83fb1bb0199d28ef84565938225"><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.4.1…6851d8bc9d67e83fb1bb0199d28ef84565938225"><code>v22.4.3</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.4.1…6851d8bc9d67e83fb1bb0199d28ef84565938225">Compare Source</a></p>
<hr />
<h3 id="v2241httpsgithubcomfacebookjestblobmasterchangelogmd82032241"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2241"><code>v22.4.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.4.0…v22.4.1">Compare Source</a></p>
<h5 id="fixes-5">Fixes</h5>
<ul>
<li><code>[jest-haste-map]</code> Parallelize Watchman calls in crawler (<a href="https://renovatebot.com/gh/facebook/jest/pull/5640">#&#8203;5640</a>)</li>
<li><code>[jest-editor-support]</code> Update TypeScript definitions (<a href="https://renovatebot.com/gh/facebook/jest/pull/5625">#&#8203;5625</a>)</li>
<li><code>[babel-jest]</code> Remove <code>retainLines</code> argument to babel. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5594">#&#8203;5594</a>)</li>
</ul>
<h5 id="features-3">Features</h5>
<ul>
<li><code>[jest-runtime]</code> Provide <code>require.main</code> property set to module with test suite (<a href="https://renovatebot.com/gh/facebook/jest/pull/5618">#&#8203;5618</a>)</li>
</ul>
<h5 id="chore--maintenance-3">Chore &amp; Maintenance</h5>
<ul>
<li><code>[docs]</code> Add note about Node version support (<a href="https://renovatebot.com/gh/facebook/jest/pull/5622">#&#8203;5622</a>)</li>
<li><code>[docs]</code> Update to use yarn (<a href="https://renovatebot.com/gh/facebook/jest/pull/5624">#&#8203;5624</a>)</li>
<li><code>[docs]</code> Add how to mock scoped modules to Manual Mocks doc (<a href="https://renovatebot.com/gh/facebook/jest/pull/5638">#&#8203;5638</a>)</li>
</ul>
<hr />
<h3 id="v2240httpsgithubcomfacebookjestblobmasterchangelogmd82032240"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#&#8203;2240"><code>v22.4.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.2.2…v22.4.0">Compare Source</a></p>
<h5 id="fixes-6">Fixes</h5>
<ul>
<li><code>[jest-haste-map]</code> Overhauls how Watchman crawler works fixing Windows (<a href="https://renovatebot.com/gh/facebook/jest/pull/5615">#&#8203;5615</a>)</li>
<li><code>[expect]</code> Allow matching of Errors against plain objects (<a href="https://renovatebot.com/gh/facebook/jest/pull/5611">#&#8203;5611</a>)</li>
<li><code>[jest-haste-map]</code> Do not read binary files in Haste, even when instructed to do so (<a href="https://renovatebot.com/gh/facebook/jest/pull/5612">#&#8203;5612</a>)</li>
<li><code>[jest-cli]</code> Don't skip matchers for exact files (<a href="https://renovatebot.com/gh/facebook/jest/pull/5582">#&#8203;5582</a>)</li>
<li><code>[docs]</code> Update discord links (<a href="https://renovatebot.com/gh/facebook/jest/pull/5586">#&#8203;5586</a>)</li>
<li><code>[jest-runtime]</code> Align handling of testRegex on Windows between searching for tests and instrumentation checks (<a href="https://renovatebot.com/gh/facebook/jest/pull/5560">#&#8203;5560</a>)</li>
<li><code>[jest-config]</code> Make it possible to merge <code>transform</code> option with preset (<a href="https://renovatebot.com/gh/facebook/jest/pull/5505">#&#8203;5505</a>)</li>
<li><code>[jest-util]</code> Fix <code>console.assert</code> behavior in custom &amp; buffered consoles (<a href="https://renovatebot.com/gh/facebook/jest/pull/5576">#&#8203;5576</a>)</li>
</ul>
<h5 id="features-4">Features</h5>
<ul>
<li><code>[docs]</code> Add MongoDB guide (<a href="https://renovatebot.com/gh/facebook/jest/pull/5571">#&#8203;5571</a>)</li>
<li><code>[jest-runtime]</code> Deprecate mapCoverage option. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5177">#&#8203;5177</a>)</li>
<li><code>[babel-jest]</code> Add option to return sourcemap from the transformer separately from source. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5177">#&#8203;5177</a>)</li>
<li><code>[jest-validate]</code> Add ability to log deprecation warnings for CLI flags. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5536">#&#8203;5536</a>)</li>
<li><code>[jest-serializer]</code> Added new module for serializing. Works using V8 or JSON (<a href="https://renovatebot.com/gh/facebook/jest/pull/5609">#&#8203;5609</a>)</li>
<li><code>[docs]</code> Add a documentation note for project <code>displayName</code> configuration (<a href="https://renovatebot.com/gh/facebook/jest/pull/5600">#&#8203;5600</a>)</li>
</ul>
<h5 id="chore--maintenance-4">Chore &amp; Maintenance</h5>
<ul>
<li><code>[docs]</code> Update automatic mocks documentation (<a href="https://renovatebot.com/gh/facebook/jest/pull/5630">#&#8203;5630</a>)</li>
</ul>
<hr />
<h3 id="v2222httpsgithubcomfacebookjestblobmasterchangelogmdjest-2222"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2222"><code>v22.2.2</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.2.0…v22.2.2">Compare Source</a></p>
<h5 id="fixes-7">Fixes</h5>
<ul>
<li><code>[babel-jest]</code> Revert "Remove retainLines from babel-jest" (<a href="https://renovatebot.com/gh/facebook/jest/pull/5496">#&#8203;5496</a>)</li>
<li><code>[jest-docblock]</code> Support multiple of the same <code>@pragma</code>. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5502">#&#8203;5154</a>)</li>
</ul>
<h5 id="features-5">Features</h5>
<ul>
<li><code>[jest-worker]</code> Assign a unique id for each worker and pass it to the child process. It will be available via <code>process.env.JEST_WORKER_ID</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5494">#&#8203;5494</a>)</li>
</ul>
<h5 id="chore--maintenance-5">Chore &amp; Maintenance</h5>
<ul>
<li><code>[filenames]</code> Standardize file names in root (<a href="https://renovatebot.com/gh/facebook/jest/pull/5500">#&#8203;5500</a>)</li>
</ul>
<hr />
<h3 id="v2220httpsgithubcomfacebookjestblobmasterchangelogmdjest-2220"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2220"><code>v22.2.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.1.0…v22.2.0">Compare Source</a></p>
<h5 id="features-6">Features</h5>
<ul>
<li><code>[jest-runner]</code> Move test summary to after coverage report (<a href="https://renovatebot.com/gh/facebook/jest/pull/4512">#&#8203;4512</a>)</li>
<li><code>[jest-cli]</code> Added <code>--notifyMode</code> to specify when to be notified. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5125">#&#8203;5125</a>)</li>
<li><code>[diff-sequences]</code> New package compares items in two sequences to find a <strong>longest common subsequence</strong>. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5407">#&#8203;5407</a>)</li>
<li><code>[jest-matcher-utils]</code> Add <code>comment</code> option to <code>matcherHint</code> function (<a href="https://renovatebot.com/gh/facebook/jest/pull/5437">#&#8203;5437</a>)</li>
<li><code>[jest-config]</code> Allow lastComit and changedFilesWithAncestor via JSON config (<a href="https://renovatebot.com/gh/facebook/jest/pull/5476">#&#8203;5476</a>)</li>
<li><code>[jest-util]</code> Add deletion to <code>process.env</code> as well (<a href="https://renovatebot.com/gh/facebook/jest/pull/5466">#&#8203;5466</a>)</li>
<li><code>[jest-util]</code> Add case-insensitive getters/setters to <code>process.env</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5465">#&#8203;5465</a>)</li>
<li><code>[jest-mock]</code> Add util methods to create async functions. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5318">#&#8203;5318</a>)</li>
</ul>
<h5 id="fixes-8">Fixes</h5>
<ul>
<li><code>[jest-cli]</code> Add trailing slash when checking root folder (<a href="https://renovatebot.com/gh/facebook/jest/pull/5464">#&#8203;5464</a>)</li>
<li><code>[jest-cli]</code> Hide interactive mode if there are no failed snapshot tests (<a href="https://renovatebot.com/gh/facebook/jest/pull/5450">#&#8203;5450</a>)</li>
<li><code>[babel-jest]</code> Remove retainLines from babel-jest (<a href="https://renovatebot.com/gh/facebook/jest/pull/5439">#&#8203;5439</a>)</li>
<li><code>[jest-cli]</code> Glob patterns ignore non-<code>require</code>-able files (e.g. <code>README.md</code>) (<a href="https://renovatebot.com/gh/facebook/jest/issues/5199">#&#8203;5199</a>)</li>
<li><code>[jest-mock]</code> Add backticks support (``) to <code>mock</code> a certain package via the <code>__mocks__</code> folder. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5426">#&#8203;5426</a>)</li>
<li><code>[jest-message-util]</code> Prevent an <code>ENOENT</code> crash when the test file contained a malformed source-map. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5405">#&#8203;5405</a>).</li>
<li><code>[jest]</code> Add <code>import-local</code> to <code>jest</code> package. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5353">#&#8203;5353</a>)</li>
<li><code>[expect]</code> Support class instances in <code>.toHaveProperty()</code> and <code>.toMatchObject</code> matcher. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5367">#&#8203;5367</a>)</li>
<li><code>[jest-cli]</code> Fix npm update command for snapshot summary. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5376">#&#8203;5376</a>, <a href="https://renovatebot.com/gh/facebook/jest/pull/5389/">5389</a>)</li>
<li><code>[expect]</code> Make <code>rejects</code> and <code>resolves</code> synchronously validate its argument. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5364">#&#8203;5364</a>)</li>
<li><code>[docs]</code> Add tutorial page for ES6 class mocks. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5383">#&#8203;5383</a>)</li>
<li><code>[jest-resolve]</code> Search required modules in node_modules and then in custom paths. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5403">#&#8203;5403</a>)</li>
<li><code>[jest-resolve]</code> Get builtin modules from node core. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5411">#&#8203;5411</a>)</li>
<li><code>[jest-resolve]</code> Detect and preserve absolute paths in <code>moduleDirectories</code>. Do not generate additional (invalid) paths by prepending each ancestor of <code>cwd</code> to the absolute path. Additionally, this fixes functionality in Windows OS. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5398">#&#8203;5398</a>)</li>
</ul>
<h5 id="chore--maintenance-6">Chore &amp; Maintenance</h5>
<ul>
<li><code>[jest-util]</code> Implement watch plugins (<a href="https://renovatebot.com/gh/facebook/jest/pull/5399">#&#8203;5399</a>)</li>
</ul>
<hr />
<h3 id="v2210httpsgithubcomfacebookjestblobmasterchangelogmdjest-2210"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2210"><code>v22.1.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/4bcfe19b89b445bec793ba0a2ac815d117fa8098…v22.1.0">Compare Source</a></p>
<h5 id="features-7">Features</h5>
<ul>
<li><code>[jest-cli]</code> Make Jest exit without an error when no tests are found in the case of <code>--lastCommit</code>, <code>--findRelatedTests</code>, or <code>--onlyChanged</code> options having been passed to the CLI</li>
<li><code>[jest-cli]</code> Add interactive snapshot mode (<a href="https://renovatebot.com/gh/facebook/jest/pull/3831">#&#8203;3831</a>)</li>
</ul>
<h5 id="fixes-9">Fixes</h5>
<ul>
<li><code>[jest-cli]</code> Use <code>import-local</code> to support global Jest installations. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5304">#&#8203;5304</a>)</li>
<li><code>[jest-runner]</code> Fix memory leak in coverage reporting (<a href="https://renovatebot.com/gh/facebook/jest/pull/5289">#&#8203;5289</a>)</li>
<li><code>[docs]</code> Update mention of the minimal version of node supported (<a href="https://renovatebot.com/gh/facebook/jest/issues/4947">#&#8203;4947</a>)</li>
<li><code>[jest-cli]</code> Fix missing newline in console message (<a href="https://renovatebot.com/gh/facebook/jest/pull/5308">#&#8203;5308</a>)</li>
<li><code>[jest-cli]</code> <code>--lastCommit</code> and <code>--changedFilesWithAncestor</code> now take effect even when <code>--onlyChanged</code> is not specified. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5307">#&#8203;5307</a>)</li>
</ul>
<h5 id="chore--maintenance-7">Chore &amp; Maintenance</h5>
<ul>
<li><code>[filenames]</code> Standardize folder names under <code>integration-tests/</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5298">#&#8203;5298</a>)</li>
</ul>
<hr />
<h3 id="v2206httpsgithubcomfacebookjestblobmasterchangelogmdjest-2206"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2206"><code>v22.0.6</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.0.4…4bcfe19b89b445bec793ba0a2ac815d117fa8098">Compare Source</a></p>
<h5 id="fixes-10">Fixes</h5>
<ul>
<li><code>[jest-jasmine2]</code> Fix memory leak in snapshot reporting (<a href="https://renovatebot.com/gh/facebook/jest/pull/5279">#&#8203;5279</a>)</li>
<li><code>[jest-config]</code> Fix breaking change in <code>--testPathPattern</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5269">#&#8203;5269</a>)</li>
<li><code>[docs]</code> Document caveat with mocks, Enzyme, snapshots and React 16 (<a href="https://renovatebot.com/gh/facebook/jest/issues/5258">#&#8203;5258</a>)</li>
</ul>
<hr />
<h3 id="v2204httpsgithubcomfacebookjestblobmasterchangelogmdjest-2204"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2204"><code>v22.0.4</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.0.3…v22.0.4">Compare Source</a></p>
<h5 id="fixes-11">Fixes</h5>
<ul>
<li><code>[jest-cli]</code> New line before quitting watch mode. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5158">#&#8203;5158</a>)</li>
</ul>
<h5 id="features-8">Features</h5>
<ul>
<li><code>[babel-jest]</code> moduleFileExtensions not passed to babel transformer. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5110">#&#8203;5110</a>)</li>
</ul>
<h5 id="chore--maintenance-8">Chore &amp; Maintenance</h5>
<ul>
<li><code>[*]</code> Tweaks to better support Node 4 (<a href="https://renovatebot.com/gh/facebook/jest/pull/5142">#&#8203;5142</a>)</li>
</ul>
<hr />
<h3 id="v2203httpsgithubcomfacebookjestblobmasterchangelogmdjest-2202--2203"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2202--2203"><code>v22.0.3</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.0.2…v22.0.3">Compare Source</a></p>
<h5 id="chore--maintenance-9">Chore &amp; Maintenance</h5>
<ul>
<li><code>[*]</code> Tweaks to better support Node 4 (<a href="https://renovatebot.com/gh/facebook/jest/pull/5134">#&#8203;5134</a>)</li>
</ul>
<hr />
<h3 id="v2202httpsgithubcomfacebookjestblobmasterchangelogmdjest-2202--2203"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2202--2203"><code>v22.0.2</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.0.1…v22.0.2">Compare Source</a></p>
<h5 id="chore--maintenance-10">Chore &amp; Maintenance</h5>
<ul>
<li><code>[*]</code> Tweaks to better support Node 4 (<a href="https://renovatebot.com/gh/facebook/jest/pull/5134">#&#8203;5134</a>)</li>
</ul>
<hr />
<h3 id="v2201httpsgithubcomfacebookjestblobmasterchangelogmdjest-2201"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2201"><code>v22.0.1</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v22.0.0…v22.0.1">Compare Source</a></p>
<h5 id="fixes-12">Fixes</h5>
<ul>
<li><code>[jest-runtime]</code> fix error for test files providing coverage. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5117">#&#8203;5117</a>)</li>
</ul>
<h5 id="features-9">Features</h5>
<ul>
<li><code>[jest-config]</code> Add <code>forceCoverageMatch</code> to allow collecting coverage from ignored files. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5081">#&#8203;5081</a>)</li>
</ul>
<hr />
<h3 id="v2200httpsgithubcomfacebookjestblobmasterchangelogmdjest-2200"><a href="https://renovatebot.com/gh/facebook/jest/blob/master/CHANGELOG.md#jest-2200"><code>v22.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/facebook/jest/compare/v21.2.0…v22.0.0">Compare Source</a></p>
<h5 id="fixes-13">Fixes</h5>
<ul>
<li><code>[jest-resolve]</code> Use <code>module.builtinModules</code> as <code>BUILTIN_MODULES</code> when it exists</li>
<li><code>[jest-worker]</code> Remove <code>debug</code> and <code>inspect</code> flags from the arguments sent to the child (<a href="https://renovatebot.com/gh/facebook/jest/pull/5068">#&#8203;5068</a>)</li>
<li><code>[jest-config]</code> Use all <code>--testPathPattern</code> and <code>&lt;regexForTestFiles&gt;</code> args in <code>testPathPattern</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/5066">#&#8203;5066</a>)</li>
<li><code>[jest-cli]</code> Do not support <code>--watch</code> inside non-version-controlled environments (<a href="https://renovatebot.com/gh/facebook/jest/pull/5060">#&#8203;5060</a>)</li>
<li><code>[jest-config]</code> Escape Windows path separator in testPathPattern CLI arguments (<a href="https://renovatebot.com/gh/facebook/jest/pull/5054">#&#8203;5054</a></li>
<li><code>[jest-jasmine]</code> Register sourcemaps as node environment to improve performance with jsdom (<a href="https://renovatebot.com/gh/facebook/jest/pull/5045">#&#8203;5045</a>)</li>
<li><code>[pretty-format]</code> Do not call toJSON recursively (<a href="https://renovatebot.com/gh/facebook/jest/pull/5044">#&#8203;5044</a>)</li>
<li><code>[pretty-format]</code> Fix errors when identity-obj-proxy mocks CSS Modules (<a href="https://renovatebot.com/gh/facebook/jest/pull/4935">#&#8203;4935</a>)</li>
<li><code>[babel-jest]</code> Fix support for namespaced babel version 7 (<a href="https://renovatebot.com/gh/facebook/jest/pull/4918">#&#8203;4918</a>)</li>
<li><code>[expect]</code> fix .toThrow for promises (<a href="https://renovatebot.com/gh/facebook/jest/pull/4884">#&#8203;4884</a>)</li>
<li><code>[jest-docblock]</code> pragmas should preserve urls (<a href="https://renovatebot.com/gh/facebook/jest/pull/4629">#&#8203;4837</a>)</li>
<li><code>[jest-cli]</code> Check if <code>npm_lifecycle_script</code> calls Jest directly (<a href="https://renovatebot.com/gh/facebook/jest/pull/4629">#&#8203;4629</a>)</li>
<li><code>[jest-cli]</code> Fix --showConfig to show all configs (<a href="https://renovatebot.com/gh/facebook/jest/pull/4494">#&#8203;4494</a>)</li>
<li><code>[jest-cli]</code> Throw if <code>maxWorkers</code> doesn't have a value (<a href="https://renovatebot.com/gh/facebook/jest/pull/4591">#&#8203;4591</a>)</li>
<li><code>[jest-cli]</code> Use <code>fs.realpathSync.native</code> if available (<a href="https://renovatebot.com/gh/facebook/jest/pull/5031">#&#8203;5031</a>)</li>
<li><code>[jest-config]</code> Fix <code>--passWithNoTests</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/4639">#&#8203;4639</a>)</li>
<li><code>[jest-config]</code> Support <code>rootDir</code> tag in testEnvironment (<a href="https://renovatebot.com/gh/facebook/jest/pull/4579">#&#8203;4579</a>)</li>
<li><code>[jest-editor-support]</code> Fix <code>--showConfig</code> to support jest 20 and jest 21 (<a href="https://renovatebot.com/gh/facebook/jest/pull/4575">#&#8203;4575</a>)</li>
<li><code>[jest-editor-support]</code> Fix editor support test for node 4 (<a href="https://renovatebot.com/gh/facebook/jest/pull/4640">#&#8203;4640</a>)</li>
<li><code>[jest-mock]</code> Support mocking constructor in <code>mockImplementationOnce</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/4599">#&#8203;4599</a>)</li>
<li><code>[jest-runtime]</code> Fix manual user mocks not working with custom resolver (<a href="https://renovatebot.com/gh/facebook/jest/pull/4489">#&#8203;4489</a>)</li>
<li><code>[jest-util]</code> Fix <code>runOnlyPendingTimers</code> for <code>setTimeout</code> inside <code>setImmediate</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/4608">#&#8203;4608</a>)</li>
<li><code>[jest-message-util]</code> Always remove node internals from stacktraces (<a href="https://renovatebot.com/gh/facebook/jest/pull/4695">#&#8203;4695</a>)</li>
<li><code>[jest-resolve]</code> changes method of determining builtin modules to include missing builtins (<a href="https://renovatebot.com/gh/facebook/jest/pull/4740">#&#8203;4740</a>)</li>
<li><code>[pretty-format]</code> Prevent error in pretty-format for window in jsdom test env (<a href="https://renovatebot.com/gh/facebook/jest/pull/4750">#&#8203;4750</a>)</li>
<li><code>[jest-resolve]</code> Preserve module identity for symlinks (<a href="https://renovatebot.com/gh/facebook/jest/pull/4761">#&#8203;4761</a>)</li>
<li><code>[jest-config]</code> Include error message for <code>preset</code> json (<a href="https://renovatebot.com/gh/facebook/jest/pull/4766">#&#8203;4766</a>)</li>
<li><code>[pretty-format]</code> Throw <code>PrettyFormatPluginError</code> if a plugin halts with an exception (<a href="https://renovatebot.com/gh/facebook/jest/pull/4787">#&#8203;4787</a>)</li>
<li><code>[expect]</code> Keep the stack trace unchanged when <code>PrettyFormatPluginError</code> is thrown by pretty-format (<a href="https://renovatebot.com/gh/facebook/jest/pull/4787">#&#8203;4787</a>)</li>
<li><code>[jest-environment-jsdom]</code> Fix asynchronous test will fail due to timeout issue. (<a href="https://renovatebot.com/gh/facebook/jest/pull/4669">#&#8203;4669</a>)</li>
<li><code>[jest-cli]</code> Fix <code>--onlyChanged</code> path case sensitivity on Windows platform (<a href="https://renovatebot.com/gh/facebook/jest/pull/4730">#&#8203;4730</a>)</li>
<li><code>[jest-runtime]</code> Use realpath to match transformers (<a href="https://renovatebot.com/gh/facebook/jest/pull/5000">#&#8203;5000</a>)</li>
<li><code>[expect]</code> [<strong>BREAKING</strong>] Replace identity equality with Object.is in toBe matcher (<a href="https://renovatebot.com/gh/facebook/jest/pull/4917">#&#8203;4917</a>)</li>
</ul>
<h5 id="features-10">Features</h5>
<ul>
<li><code>[jest-message-util]</code> Add codeframe to test assertion failures (<a href="https://renovatebot.com/gh/facebook/jest/pull/5087">#&#8203;5087</a>)</li>
<li><code>[jest-config]</code> Add Global Setup/Teardown options (<a href="https://renovatebot.com/gh/facebook/jest/pull/4716">#&#8203;4716</a>)</li>
<li><code>[jest-config]</code> Add <code>testEnvironmentOptions</code> to apply to jsdom options or node context. (<a href="https://renovatebot.com/gh/facebook/jest/pull/5003">#&#8203;5003</a>)</li>
<li><code>[jest-jasmine2]</code> Update Timeout error message to <code>jest.timeout</code> and display current timeout value (<a href="https://renovatebot.com/gh/facebook/jest/pull/4990">#&#8203;4990</a>)</li>
<li><code>[jest-runner]</code> Enable experimental detection of leaked contexts (<a href="https://renovatebot.com/gh/facebook/jest/pull/4895">#&#8203;4895</a>)</li>
<li><code>[jest-cli]</code> Add combined coverage threshold for directories. (<a href="https://renovatebot.com/gh/facebook/jest/pull/4885">#&#8203;4885</a>)</li>
<li><code>[jest-mock]</code> Add <code>timestamps</code> to mock state. (<a href="https://renovatebot.com/gh/facebook/jest/pull/4866">#&#8203;4866</a>)</li>
<li><code>[eslint-plugin-jest]</code> Add <code>prefer-to-have-length</code> lint rule. (<a href="https://renovatebot.com/gh/facebook/jest/pull/4771">#&#8203;4771</a>)</li>
<li><code>[jest-environment-jsdom]</code> [<strong>BREAKING</strong>] Upgrade to JSDOM@&#8203;11 (<a href="https://renovatebot.com/gh/facebook/jest/pull/4770">#&#8203;4770</a>)</li>
<li><code>[jest-environment-*]</code> [<strong>BREAKING</strong>] Add Async Test Environment APIs, dispose is now teardown (<a href="https://renovatebot.com/gh/facebook/jest/pull/4506">#&#8203;4506</a>)</li>
<li><code>[jest-cli]</code> Add an option to clear the cache (<a href="https://renovatebot.com/gh/facebook/jest/pull/4430">#&#8203;4430</a>)</li>
<li><code>[babel-plugin-jest-hoist]</code> Improve error message, that the second argument of <code>jest.mock</code> must be an inline function (<a href="https://renovatebot.com/gh/facebook/jest/pull/4593">#&#8203;4593</a>)</li>
<li><code>[jest-snapshot]</code> [<strong>BREAKING</strong>] Concatenate name of test and snapshot (<a href="https://renovatebot.com/gh/facebook/jest/pull/4460">#&#8203;4460</a>)</li>
<li><code>[jest-cli]</code> [<strong>BREAKING</strong>] Fail if no tests are found (<a href="https://renovatebot.com/gh/facebook/jest/pull/3672">#&#8203;3672</a>)</li>
<li><code>[jest-diff]</code> Highlight only last of odd length leading spaces (<a href="https://renovatebot.com/gh/facebook/jest/pull/4558">#&#8203;4558</a>)</li>
<li><code>[jest-docblock]</code> Add <code>docblock.print()</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/4517">#&#8203;4517</a>)</li>
<li><code>[jest-docblock]</code> Add <code>strip</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/4571">#&#8203;4571</a>)</li>
<li><code>[jest-docblock]</code> Preserve leading whitespace in docblock comments (<a href="https://renovatebot.com/gh/facebook/jest/pull/4576">#&#8203;4576</a>)</li>
<li><code>[jest-docblock]</code> remove leading newlines from <code>parswWithComments().comments</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/4610">#&#8203;4610</a>)</li>
<li><code>[jest-editor-support]</code> Add Snapshots metadata (<a href="https://renovatebot.com/gh/facebook/jest/pull/4570">#&#8203;4570</a>)</li>
<li><code>[jest-editor-support]</code> Adds an 'any' to the typedef for <code>updateFileWithJestStatus</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/4636">#&#8203;4636</a>)</li>
<li><code>[jest-editor-support]</code> Better monorepo support (<a href="https://renovatebot.com/gh/facebook/jest/pull/4572">#&#8203;4572</a>)</li>
<li><code>[jest-environment-jsdom]</code> Add simple rAF polyfill in jsdom environment to work with React 16 (<a href="https://renovatebot.com/gh/facebook/jest/pull/4568">#&#8203;4568</a>)</li>
<li><code>[jest-environment-node]</code> Implement node Timer api (<a href="https://renovatebot.com/gh/facebook/jest/pull/4622">#&#8203;4622</a>)</li>
<li><code>[jest-jasmine2]</code> Add testPath to reporter callbacks (<a href="https://renovatebot.com/gh/facebook/jest/pull/4594">#&#8203;4594</a>)</li>
<li><code>[jest-mock]</code> Added support for naming mocked functions with <code>.mockName(value)</code> and <code>.mockGetName()</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/4586">#&#8203;4586</a>)</li>
<li><code>[jest-runtime]</code> Add <code>module.loaded</code>, and make <code>module.require</code> not enumerable (<a href="https://renovatebot.com/gh/facebook/jest/pull/4623">#&#8203;4623</a>)</li>
<li><code>[jest-runtime]</code> Add <code>module.parent</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/4614">#&#8203;4614</a>)</li>
<li><code>[jest-runtime]</code> Support sourcemaps in transformers (<a href="https://renovatebot.com/gh/facebook/jest/pull/3458">#&#8203;3458</a>)</li>
<li><code>[jest-snapshot]</code> [<strong>BREAKING</strong>] Add a serializer for <code>jest.fn</code> to allow a snapshot of a jest mock (<a href="https://renovatebot.com/gh/facebook/jest/pull/4668">#&#8203;4668</a>)</li>
<li><code>[jest-worker]</code> Initial version of parallel worker abstraction, say hello! (<a href="https://renovatebot.com/gh/facebook/jest/pull/4497">#&#8203;4497</a>)</li>
<li><code>[jest-jasmine2]</code> Add <code>testLocationInResults</code> flag to add location information per spec to test results (<a href="https://renovatebot.com/gh/facebook/jest/pull/4782">#&#8203;4782</a>)</li>
<li><code>[jest-environment-jsdom]</code> Update JSOM to 11.4, which includes built-in support for <code>requestAnimationFrame</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/4919">#&#8203;4919</a>)</li>
<li><code>[jest-cli]</code> Hide watch usage output when running on non-interactive environments (<a href="https://renovatebot.com/gh/facebook/jest/pull/4958">#&#8203;4958</a>)</li>
<li><code>[jest-snapshot]</code> Promises support for <code>toThrowErrorMatchingSnapshot</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/4946">#&#8203;4946</a>)</li>
<li><code>[jest-cli]</code> Explain which snapshots are obsolete (<a href="https://renovatebot.com/gh/facebook/jest/pull/5005">#&#8203;5005</a>)</li>
</ul>
<h5 id="chore--maintenance-11">Chore &amp; Maintenance</h5>
<ul>
<li><code>[docs]</code> Add guide of using with puppeteer (<a href="https://renovatebot.com/gh/facebook/jest/pull/5093">#&#8203;5093</a>)</li>
<li><code>[jest-util]</code> <code>jest-util</code> should not depend on <code>jest-mock</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/4992">#&#8203;4992</a>)</li>
<li><code>[*]</code> [<strong>BREAKING</strong>] Drop support for Node.js version 4 (<a href="https://renovatebot.com/gh/facebook/jest/pull/4769">#&#8203;4769</a>)</li>
<li><code>[docs]</code> Wrap code comments at 80 characters (<a href="https://renovatebot.com/gh/facebook/jest/pull/4781">#&#8203;4781</a>)</li>
<li><code>[eslint-plugin-jest]</code> Removed from the Jest core repo, and moved to <a href="https://renovatebot.com/gh/jest-community/eslint-plugin-jest">https://github.com/jest-community/eslint-plugin-jest</a> (<a href="https://renovatebot.com/gh/facebook/jest/pull/4867">#&#8203;4867</a>)</li>
<li><code>[babel-jest]</code> Explicitly bump istanbul to newer versions (<a href="https://renovatebot.com/gh/facebook/jest/pull/4616">#&#8203;4616</a>)</li>
<li><code>[expect]</code> Upgrade mocha and rollup for browser testing (<a href="https://renovatebot.com/gh/facebook/jest/pull/4642">#&#8203;4642</a>)</li>
<li><code>[docs]</code> Add info about <code>coveragePathIgnorePatterns</code> (<a href="https://renovatebot.com/gh/facebook/jest/pull/4602">#&#8203;4602</a>)</li>
<li><code>[docs]</code> Add Vuejs series of testing with Jest (<a href="https://renovatebot.com/gh/facebook/jest/pull/4648">#&#8203;4648</a>)</li>
<li><code>[docs]</code> Mention about optional <code>done</code> argument in test function (<a href="https://renovatebot.com/gh/facebook/jest/pull/4556">#&#8203;4556</a>)</li>
<li><code>[jest-cli]</code> Bump node-notifier version (<a href="https://renovatebot.com/gh/facebook/jest/pull/4609">#&#8203;4609</a>)</li>
<li><code>[jest-diff]</code> Simplify highlight for leading and trailing spaces (<a href="https://renovatebot.com/gh/facebook/jest/pull/4553">#&#8203;4553</a>)</li>
<li><code>[jest-get-type]</code> Add support for date (<a href="https://renovatebot.com/gh/facebook/jest/pull/4621">#&#8203;4621</a>)</li>
<li><code>[jest-matcher-utils]</code> Call <code>chalk.inverse</code> for trailing spaces (<a href="https://renovatebot.com/gh/facebook/jest/pull/4578">#&#8203;4578</a>)</li>
<li><code>[jest-runtime]</code> Add <code>.advanceTimersByTime</code>; keep <code>.runTimersToTime()</code> as an alias.</li>
<li><code>[docs]</code> Include missing dependency in TestEnvironment sample code</li>
<li><code>[docs]</code> Add clarification for hook execution order</li>
<li><code>[docs]</code> Update <code>expect.anything()</code> sample code (<a href="https://renovatebot.com/gh/facebook/jest/pull/5007">#&#8203;5007</a>)</li>
</ul>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>