### PR TITLE
chore(deps): update dependency @dcos/http-service to v1 - autoclosed

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@dcos/copychars": "0.1.2",
-    "@dcos/http-service": "0.3.0",
+    "@dcos/http-service": "1.0.0",
     "@dcos/recordio": "0.1.8",
     "rxjs": "5.4.3"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,9 +31,9 @@
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@dcos/copychars/-/copychars-0.1.2.tgz#c29c759fe6ed140689324b527cb4d6fbab71090b"
 
-"@dcos/http-service@0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@dcos/http-service/-/http-service-0.3.0.tgz#3f174260dd48b3ddbba592319c92a1c16a7ac0a5"
+"@dcos/http-service@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@dcos/http-service/-/http-service-1.0.0.tgz#812c2445b7d4add04fd93479fe50e123d554cf89"
   dependencies:
     "@dcos/connection-manager" "0.2.1"
     "@dcos/connections" "0.1.0"


### PR DESCRIPTION
<p>This Pull Request updates dependency <code>@dcos/http-service</code> (<a href="https://renovatebot.com/gh/dcos-labs/http-service">source</a>) from <code>v0.3.0</code> to <code>v1.0.0</code></p>
<p><details><br />
<summary>Release Notes</summary></p>
<h3 id="v100httpsgithubcomdcos-labshttp-serviceblobmasterchangelogmd8203100httpsgithubcomdcos-labshttp-servicecomparev030v100-2018-08-27"><a href="https://renovatebot.com/gh/dcos-labs/http-service/blob/master/CHANGELOG.md#&#8203;100httpsgithubcomdcos-labshttp-servicecomparev030v100-2018-08-27"><code>v1.0.0</code></a></h3>
<p><a href="https://renovatebot.com/gh/dcos-labs/http-service/compare/v0.3.0…v1.0.0">Compare Source</a></p>
<h5 id="features">Features</h5>
<ul>
<li><strong>request:</strong> add status code to next event (<a href="https://renovatebot.com/gh/dcos-labs/http-service/commit/c8bc7b5">c8bc7b5</a>)</li>
</ul>
<h5 id="breaking-changes">BREAKING CHANGES</h5>
<ul>
<li><strong>request:</strong> the output format of the next event changed. Instead of<br />
<code>request(...).subscribe({next(response) {...}})</code> you can now write<br />
<code>request(...).subscribe({next({ code, response }) {...}})</code></li>
</ul>
<hr />
<p></details></p>
<hr />
<p>This PR has been generated by <a href="https://renovatebot.com">Renovate Bot</a>.</p>