### PR TITLE
DCOS-46038: update rxjs to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "@dcos/copychars": "0.1.2",
     "@dcos/http-service": "1.0.0",
     "@dcos/recordio": "0.1.8",
-    "rxjs": "5.4.3"
+    "rxjs": "6.3.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@dcos/copychars": "0.1.2",
-    "@dcos/http-service": "1.1.0",
+    "@dcos/http-service": "2.0.0",
     "@dcos/recordio": "0.1.8",
     "rxjs": "6.3.3"
   }

--- a/src/request.js
+++ b/src/request.js
@@ -1,4 +1,5 @@
 import { request as httpRequest } from "@dcos/http-service";
+import { map } from "rxjs/operators";
 
 export default function request(body, url = "/mesos/api/v1") {
   return httpRequest(url, {
@@ -9,5 +10,5 @@ export default function request(body, url = "/mesos/api/v1") {
       "Content-Type": "application/json",
       Accept: "application/json"
     }
-  }).map(({ response }) => response);
+  }).pipe(map(({ response }) => response));
 }

--- a/src/stream/__tests__/parseRecordioRecords-test.js
+++ b/src/stream/__tests__/parseRecordioRecords-test.js
@@ -1,4 +1,5 @@
-import Rx from "rxjs";
+import { from } from "rxjs";
+import { reduce } from "rxjs/operators";
 import parseRecordioRecords from "../parseRecordioRecords";
 
 describe("#parseRecordioRecords", function() {
@@ -7,8 +8,10 @@ describe("#parseRecordioRecords", function() {
   ) {
     const chunks = ['11\n{"test": 1}', '11\n{"test": 1}14\n{"another": 2}'];
 
-    parseRecordioRecords(Rx.Observable.from(chunks))
-      .reduce((acc, current) => acc.concat(current), [])
+    parseRecordioRecords(from(chunks))
+      .pipe(
+        reduce((acc, current) => acc.concat(current), [])
+      )
       .subscribe(function(value) {
         expect(value).toEqual(['{"test": 1}', '{"another": 2}']);
 

--- a/src/stream/__tests__/readRecordioRecords-test.js
+++ b/src/stream/__tests__/readRecordioRecords-test.js
@@ -1,4 +1,5 @@
-import Rx from "rxjs";
+import { from } from "rxjs";
+import { scan, reduce } from "rxjs/operators";
 import readRecordioRecords from "../readRecordioRecords";
 
 describe("#readRecordioRecords", function() {
@@ -13,10 +14,11 @@ describe("#readRecordioRecords", function() {
       "1\n12\n223\n3334\n4444"
     ];
 
-    Rx.Observable
-      .from(chunks)
-      .scan(readRecordioRecords, {})
-      .reduce((acc, current) => acc.concat(current), [])
+    from(chunks)
+      .pipe(
+        scan(readRecordioRecords, {}),
+        reduce((acc, current) => acc.concat(current), [])
+      )
       .subscribe(function(value) {
         expect(value).toEqual([
           { records: ["1"], buffer: "", position: 3 },

--- a/src/stream/parseRecordioRecords.js
+++ b/src/stream/parseRecordioRecords.js
@@ -1,9 +1,11 @@
-import Rx from "rxjs";
+import { from } from "rxjs";
+import { map, scan, concatAll } from "rxjs/operators";
 import readRecordioRecords from "./readRecordioRecords";
 
 export default function parseRecordioRecords(resource) {
-  return resource
-    .scan(readRecordioRecords, {})
-    .map(({ records }) => Rx.Observable.from(records))
-    .concatAll();
+  return resource.pipe(
+    scan(readRecordioRecords, {}),
+    map(({ records }) => from(records)),
+    concatAll()
+  );
 }


### PR DESCRIPTION
Update rxjs to version 6.3.3.

Closes DCOS-46038.

## Important

This library is a dependency of `dcos-ui` and has `http-service` as a dependency. Hold merge until those repositories are also able to update to rxjs 6.x.
